### PR TITLE
fix(db): revoke PUBLIC access from SECURITY DEFINER functions

### DIFF
--- a/supabase/migrations/20260501000000_fix_security_definer_permissions.sql
+++ b/supabase/migrations/20260501000000_fix_security_definer_permissions.sql
@@ -1,0 +1,30 @@
+-- Fix SECURITY DEFINER function permissions
+-- Issue: 5 SECURITY DEFINER functions were executable by PUBLIC via PostgREST
+-- because REVOKE was never issued, only GRANT (which is additive).
+-- This prevents email addresses and other sensitive data from being exposed.
+-- ref: https://github.com/Divkix/pickmyclass/issues/159
+
+-- get_class_watchers: Returns user emails watching a class section
+REVOKE EXECUTE ON FUNCTION public.get_class_watchers(TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_class_watchers(TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_class_watchers(TEXT) TO service_role;
+
+-- get_watchers_for_sections: Bulk fetches watcher emails for multiple sections
+REVOKE EXECUTE ON FUNCTION public.get_watchers_for_sections(TEXT[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_watchers_for_sections(TEXT[]) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_watchers_for_sections(TEXT[]) TO service_role;
+
+-- get_sections_to_check: Returns distinct sections for staggered cron processing
+REVOKE EXECUTE ON FUNCTION public.get_sections_to_check(TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_sections_to_check(TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_sections_to_check(TEXT) TO service_role;
+
+-- try_record_notifications_batch: Atomically records notifications to prevent duplicates
+REVOKE EXECUTE ON FUNCTION public.try_record_notifications_batch(UUID[], TEXT, INTEGER) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.try_record_notifications_batch(UUID[], TEXT, INTEGER) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.try_record_notifications_batch(UUID[], TEXT, INTEGER) TO service_role;
+
+-- delete_notification_records: Deletes notification records for given watch IDs
+REVOKE EXECUTE ON FUNCTION public.delete_notification_records(UUID[], TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.delete_notification_records(UUID[], TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_notification_records(UUID[], TEXT) TO service_role;


### PR DESCRIPTION
Fixes #159

## Summary
- REVOKE EXECUTE FROM PUBLIC and authenticated on 5 SECURITY DEFINER functions
- GRANT EXECUTE TO service_role for all 5 functions
- Matches the access control pattern from `create_class_watch_with_limit` migration

## Affected functions
- `get_class_watchers` — returns user emails watching a class
- `get_watchers_for_sections` — bulk fetches watcher emails for sections
- `get_sections_to_check` — returns distinct sections for cron processing
- `try_record_notifications_batch` — atomically records notification deduplication
- `delete_notification_records` — deletes notification records for watch IDs

## TDD
- TDD exception: Migration-only SQL change. PostgreSQL permission changes cannot be tested without a running database instance. The project test suite uses mock Supabase clients.
- Alternative validation: migration syntax matches the established pattern from migration `20260414171000`

## Validation
- `bun run lint:fix && bun run format` — passed (1 pre-existing info about schema version)
- `bun run type-check` — passed, no errors
- `bun run test:run` — 19 files / 338 tests passed

## Risk
- Medium — SQL migration only, no application code changes. Migration is idempotent (REVOKE/GRANT can be re-run safely). Backend uses service_role client so all 5 functions continue to work after this change.