### PR TITLE
fix: ASU API timeout errors produce unhelpful logs and no specific error type

### DIFF
--- a/lib/asu/api.ts
+++ b/lib/asu/api.ts
@@ -168,10 +168,18 @@ export async function fetchClassFromASU(
   const url = buildClassSearchUrl(env.ASU_API_BASE_URL, classNbr, term);
   const authHeader = normalizeAuthHeader(env.ASU_API_TOKEN);
 
-  const response = await fetch(url, {
-    headers: { Authorization: authHeader },
-    signal: AbortSignal.timeout(10_000),
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { Authorization: authHeader },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'TimeoutError') {
+      throw new ApiError('ASU API request timed out', 408);
+    }
+    throw error;
+  }
 
   if (response.status === 401 || response.status === 403) {
     throw new AuthError('ASU API token expired or invalid');

--- a/tests/unit/lib/asu-api.test.ts
+++ b/tests/unit/lib/asu-api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { clearAsuApiCache, fetchClassFromASU } from '@/lib/asu/api';
+import { ApiError, clearAsuApiCache, fetchClassFromASU } from '@/lib/asu/api';
 
 function buildAsuSuccessResponse() {
   return {
@@ -85,5 +85,33 @@ describe('fetchClassFromASU', () => {
     expect(init).toMatchObject({
       headers: { Authorization: 'Bearer null' },
     });
+  });
+
+  it('should throw ApiError with status 408 when fetch times out', async () => {
+    const timeoutError = new DOMException('The operation was aborted.', 'TimeoutError');
+    vi.spyOn(global, 'fetch').mockRejectedValue(timeoutError);
+
+    await expect(
+      fetchClassFromASU('42737', '2264', {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'test-token',
+      })
+    ).rejects.toSatisfy((error: unknown) => {
+      return error instanceof ApiError && error.status === 408;
+    });
+  });
+
+  it('should throw ApiError with timeout message when fetch times out', async () => {
+    const timeoutError = new DOMException('The operation was aborted.', 'TimeoutError');
+    vi.spyOn(global, 'fetch').mockRejectedValue(timeoutError);
+
+    await expect(
+      fetchClassFromASU('42737', '2264', {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'test-token',
+      })
+    ).rejects.toThrow('ASU API request timed out');
   });
 });


### PR DESCRIPTION
Fixes #179

## Summary
- Catches DOMException TimeoutError from fetch() when ASU API request times out
- Throws ApiError with status 408 and clear message 'ASU API request timed out'
- Improves observability for timeout vs other failure modes

## TDD
- Red: Added 2 tests expecting ApiError with status 408 for timeout errors - both failed (DOMException propagated instead)
- Green: Added try-catch around fetch() to catch DOMException with name 'TimeoutError' and throw ApiError with status 408
- Refactor: Code passes all 342 tests

## Validation
- All 342 tests pass (added 2 new tests)
- TypeScript type check passes
- Biome lint/format passes
- Build passes

## Risk
- Low: Only affects timeout error handling path, no changes to success paths or other error handling
- Timeout errors now get proper HTTP 408 status instead of generic 500

## Auto-merge readiness
- Ready: All validations pass, scoped change, tests cover new behavior