### PR TITLE
fix: memoize supabase client to prevent unnecessary auth calls

### DIFF
--- a/lib/contexts/AuthContext.tsx
+++ b/lib/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { Session, User } from '@supabase/supabase-js';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 
 interface AuthContextType {
@@ -17,7 +17,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
 
   useEffect(() => {
     // Get initial session - use getUser() to sync with server-set HTTP-only cookies

--- a/tests/unit/lib/contexts/AuthContext.test.tsx
+++ b/tests/unit/lib/contexts/AuthContext.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AuthProvider } from '@/lib/contexts/AuthContext';
+
+// Mock the supabase client module
+const mockSupabaseClient = {
+  auth: {
+    getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({
+      data: {
+        subscription: {
+          unsubscribe: vi.fn(),
+        },
+      },
+    }),
+  },
+};
+
+// Track createClient calls
+const createClientMock = vi.fn().mockReturnValue(mockSupabaseClient);
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => createClientMock(),
+}));
+
+describe('AuthContext', () => {
+  it('should memoize supabase client and not recreate it on re-renders', async () => {
+    // Reset call count
+    createClientMock.mockClear();
+
+    // Create a component that triggers re-renders
+    let renderCount = 0;
+    function TestComponent() {
+      renderCount++;
+      return <div data-testid="render-count">{renderCount}</div>;
+    }
+
+    function App() {
+      return (
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+    }
+
+    // Initial render
+    const { rerender } = render(<App />);
+
+    // Wait for initial auth check
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Trigger multiple re-renders
+    rerender(<App />);
+    rerender(<App />);
+    rerender(<App />);
+
+    // Wait for any async effects
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Verify createClient was called exactly once
+    expect(createClientMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('render-count').textContent).toBe('4');
+  });
+});


### PR DESCRIPTION
Fixes #175

## Summary
The AuthContext was calling createClient() on every render, creating a new supabase.auth reference each time. This caused the useEffect([supabase.auth]) to re-run unnecessarily, triggering redundant getUser() calls and subscription teardown/recreation.

## Changes
- Wrap createClient() in useMemo(() => createClient(), []) to create the client only once
- Add useMemo to React imports
- Add regression test to verify client is memoized across re-renders

## TDD
- Red: Added test that creates 4 re-renders and verifies createClient is called only once. Test failed with expected 1 times, but got 5 times - confirming the bug
- Green: Wrapped createClient in useMemo - test passes
- Refactor: No additional refactoring needed

## Validation
- All 343 tests pass (342 existing + 1 new)
- TypeScript type check passes
- Biome linter passes
- Knip passes

## Risk
- Low: Minimal change (2 lines modified), only affects client creation timing. No breaking API changes.

## Auto-merge readiness
- Ready: Low-risk performance fix with comprehensive test coverage