### PR TITLE
fix(login): prevent OAuth button reset before navigation

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -122,11 +122,12 @@ function LoginForm() {
 
       if (error) {
         setError(error.message);
+        setGoogleLoading(false);
       }
+      // Note: we don't reset loading on success because browser will navigate away
     } catch (err) {
       setError('Failed to initiate Google sign-in');
       console.error(err);
-    } finally {
       setGoogleLoading(false);
     }
   };

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -204,11 +204,12 @@ export default function RegisterPage() {
 
       if (error) {
         setError(error.message);
+        setGoogleLoading(false);
       }
+      // Note: we don't reset loading on success because browser will navigate away
     } catch (err) {
       setError('Failed to initiate Google sign-up');
       console.error(err);
-    } finally {
       setGoogleLoading(false);
     }
   };

--- a/tests/unit/app/login/page.test.tsx
+++ b/tests/unit/app/login/page.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LoginPage from '@/app/login/page';
+import { AuthProvider } from '@/lib/contexts/AuthContext';
+
+// Mock the supabase client module
+const mockSignInWithOAuth = vi.fn();
+const mockSupabaseClient = {
+  auth: {
+    signInWithOAuth: mockSignInWithOAuth,
+    getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    }),
+  },
+};
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabaseClient,
+}));
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe('LoginPage - Google OAuth loading state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignInWithOAuth.mockReset();
+  });
+
+  it('should keep loading state true after successful OAuth initiation', async () => {
+    // Mock successful OAuth initiation
+    mockSignInWithOAuth.mockResolvedValue({ error: null });
+
+    render(
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>
+    );
+
+    // Find the Google sign-in button
+    const googleButton = screen.getByRole('button', { name: /sign in with google/i });
+
+    // Click the button
+    fireEvent.click(googleButton);
+
+    // Wait for loading state to be set
+    await waitFor(() => {
+      expect(mockSignInWithOAuth).toHaveBeenCalled();
+    });
+
+    // The button should still be in loading state because
+    // successful OAuth doesn't reset loading (browser will navigate away)
+    expect(googleButton).toHaveTextContent(/redirecting to google/i);
+  });
+
+  it('should reset loading state on OAuth error', async () => {
+    // Mock OAuth error
+    mockSignInWithOAuth.mockResolvedValue({ error: { message: 'OAuth failed' } });
+
+    render(
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>
+    );
+
+    const googleButton = screen.getByRole('button', { name: /sign in with google/i });
+
+    fireEvent.click(googleButton);
+
+    // Wait for error to be shown
+    await waitFor(() => {
+      expect(screen.getByText(/oauth failed/i)).toBeInTheDocument();
+    });
+
+    // Button should be back to normal state
+    expect(googleButton).toHaveTextContent(/sign in with google/i);
+  });
+});

--- a/tests/unit/app/register/page.test.tsx
+++ b/tests/unit/app/register/page.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import RegisterPage from '@/app/register/page';
+import { AuthProvider } from '@/lib/contexts/AuthContext';
+
+// Mock the supabase client module
+const mockSignInWithOAuth = vi.fn();
+const mockSupabaseClient = {
+  auth: {
+    signInWithOAuth: mockSignInWithOAuth,
+    getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+    getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+    onAuthStateChange: vi.fn().mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    }),
+  },
+};
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabaseClient,
+}));
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe('RegisterPage - Google OAuth loading state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignInWithOAuth.mockReset();
+  });
+
+  it('should keep loading state true after successful OAuth initiation', async () => {
+    // Mock successful OAuth initiation
+    mockSignInWithOAuth.mockResolvedValue({ error: null });
+
+    render(
+      <AuthProvider>
+        <RegisterPage />
+      </AuthProvider>
+    );
+
+    // Check the required checkboxes first
+    const ageCheckbox = screen.getByLabelText(/i am 18 years or older/i);
+    const termsCheckbox = screen.getByLabelText(/i agree to the terms/i);
+
+    fireEvent.click(ageCheckbox);
+    fireEvent.click(termsCheckbox);
+
+    // Find the Google sign-up button
+    const googleButton = screen.getByRole('button', { name: /sign up with google/i });
+
+    // Click the button
+    fireEvent.click(googleButton);
+
+    // Wait for loading state to be set
+    await waitFor(() => {
+      expect(mockSignInWithOAuth).toHaveBeenCalled();
+    });
+
+    // The button should still be in loading state because
+    // successful OAuth doesn't reset loading (browser will navigate away)
+    expect(googleButton).toHaveTextContent(/redirecting to google/i);
+  });
+
+  it('should reset loading state on OAuth error', async () => {
+    // Mock OAuth error
+    mockSignInWithOAuth.mockResolvedValue({ error: { message: 'OAuth failed' } });
+
+    render(
+      <AuthProvider>
+        <RegisterPage />
+      </AuthProvider>
+    );
+
+    // Check the required checkboxes first
+    const ageCheckbox = screen.getByLabelText(/i am 18 years or older/i);
+    const termsCheckbox = screen.getByLabelText(/i agree to the terms/i);
+
+    fireEvent.click(ageCheckbox);
+    fireEvent.click(termsCheckbox);
+
+    const googleButton = screen.getByRole('button', { name: /sign up with google/i });
+
+    fireEvent.click(googleButton);
+
+    // Wait for error to be shown
+    await waitFor(() => {
+      expect(screen.getByText(/oauth failed/i)).toBeInTheDocument();
+    });
+
+    // Button should be back to normal state
+    expect(googleButton).toHaveTextContent(/sign up with google/i);
+  });
+});


### PR DESCRIPTION
Fixes #176

## Summary
Fixed the Google OAuth button briefly resetting from 'Redirecting to Google...' back to 'Sign in with Google' before browser navigation occurs. This was caused by setting loading=false in a finally block, which executed regardless of whether OAuth succeeded or failed.

## Changes
- **app/login/page.tsx**: Removed finally block that reset googleLoading state; now only resets on error (catch block or error response)
- **app/register/page.tsx**: Same fix applied to handleGoogleSignUp function
- **tests/unit/app/login/page.test.tsx**: Added tests for loading state behavior
- **tests/unit/app/register/page.test.tsx**: Added tests for loading state behavior

## TDD
- Red: Created tests that verified the button incorrectly resets to normal state after successful OAuth initiation (failed as expected)
- Green: Fixed both login and register pages by removing finally block and only resetting loading on errors
- Refactor: Added explanatory comment about why loading isn't reset on success

## Validation
- All 343+4 tests pass (21 test files)
- Linting passes (Biome)
- Type checking passes (TypeScript)

## Risk
- **Low**: UI-only fix, no data migration or auth changes. Button state now correctly stays in loading mode until browser navigates away to Google OAuth.

## Auto-merge readiness
- Ready for merge once checks pass
