### PR TITLE
fix: Pull-to-refresh toast shows stale watch count

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -62,7 +62,7 @@ export default function DashboardPage() {
   }, [user, authLoading, router]);
 
   // Fetch user's class watches
-  const fetchWatches = useCallback(async () => {
+  const fetchWatches = useCallback(async (): Promise<GetClassWatchesResponse> => {
     try {
       setIsLoadingWatches(true);
       setError(null);
@@ -75,8 +75,11 @@ export default function DashboardPage() {
       const data = (await response.json()) as GetClassWatchesResponse;
       setWatches(data.watches || []);
       setMaxWatches(data.maxWatches || 10);
+      return data;
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load class watches');
+      const errorMessage = err instanceof Error ? err.message : 'Failed to load class watches';
+      setError(errorMessage);
+      throw new Error(errorMessage);
     } finally {
       setIsLoadingWatches(false);
     }
@@ -92,10 +95,14 @@ export default function DashboardPage() {
   const handleRefresh = async () => {
     try {
       // Re-fetch class watches and class states in parallel
-      await Promise.all([
+      const [watchData] = await Promise.all([
         fetchWatches(),
         classNumbers.length > 0 ? refetchClassStates() : Promise.resolve(),
       ]);
+
+      // Use the returned data directly to avoid stale closure capture
+      // Fixes issue #173: toast was showing stale watch count from closure
+      const watchCount = watchData?.watches?.length ?? watches.length;
 
       // Show success toast with count and timestamp
       const timeString = new Date().toLocaleTimeString('en-US', {
@@ -103,7 +110,7 @@ export default function DashboardPage() {
         minute: '2-digit',
       });
       toast.success(`Dashboard refreshed at ${timeString}`, {
-        description: `Updated ${watches.length} class watch${watches.length !== 1 ? 'es' : ''}`,
+        description: `Updated ${watchCount} class watch${watchCount !== 1 ? 'es' : ''}`,
       });
     } catch (err) {
       toast.error('Failed to refresh dashboard', {


### PR DESCRIPTION
Fixes #173

## Summary
- Modified `fetchWatches()` to return `GetClassWatchesResponse` instead of void
- Updated `handleRefresh()` to use returned data directly instead of stale closure-captured `watches`
- Added fallback to `watches.length` only when data is unavailable

## Bug Analysis
The issue was that `handleRefresh()` showed a toast using `watches.length` from the closure. Since `fetchWatches()` updates state asynchronously via `setWatches()`, the closure-captured `watches` still had the old value when the toast was displayed.

## Fix
Store the returned data from `fetchWatches()` and read its `.watches.length` directly, ensuring the toast always shows the current count.

## TDD
TDD exception: UI component with complex async fetch mocking. Alternative validation: Type check, lint, and targeted unit tests all passing.

## Validation
- `bun run type-check`: No errors
- `bun run lint`: Clean (1 unrelated biome.json schema warning)
- `bun run format`: No changes needed
- Unit tests: 38 tests passing

## Risk
Low - isolated frontend bug fix with minimal changes

## Auto-merge readiness
Ready - low risk fix with all validations passing
