### PR TITLE
fix(cron): return success:false when queue batches fail

### DIFF
--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -170,14 +170,20 @@ export async function GET(request: NextRequest) {
       `[Cron] Enqueued ${sections.length} sections in ${duration}ms (${successfulBatches}/${batches.length} batches succeeded)`
     );
 
-    return NextResponse.json({
-      success: true,
-      sections_enqueued: sections.length,
-      batches_total: batches.length,
-      batches_failed: failedBatches.length,
-      stagger_group: staggerGroup,
-      duration,
-    });
+    // Return success:false if any batches failed
+    const hasFailedBatches = failedBatches.length > 0;
+
+    return NextResponse.json(
+      {
+        success: !hasFailedBatches,
+        sections_enqueued: sections.length,
+        batches_total: batches.length,
+        batches_failed: failedBatches.length,
+        stagger_group: staggerGroup,
+        duration,
+      },
+      { status: hasFailedBatches ? 207 : 200 } // 207 Multi-Status for partial failures
+    );
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     console.error('[Cron] Fatal error:', errorMessage);

--- a/tests/integration/api/cron.test.ts
+++ b/tests/integration/api/cron.test.ts
@@ -1,0 +1,128 @@
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock modules before importing route
+vi.mock('@/lib/db/queries', () => ({
+  getSectionsToCheck: vi.fn(),
+}));
+
+vi.mock('cloudflare:workers', () => ({
+  env: {
+    CRON_SECRET: 'test-cron-secret',
+    PICKMYCLASS_QUEUE: {
+      sendBatch: vi.fn(),
+    },
+  },
+}));
+
+import { GET } from '@/app/api/cron/route';
+import { getSectionsToCheck } from '@/lib/db/queries';
+
+function createRequest(authHeader?: string): NextRequest {
+  return new NextRequest('http://localhost:3000/api/cron', {
+    method: 'GET',
+    headers: authHeader ? { Authorization: authHeader } : {},
+  });
+}
+
+describe('GET /api/cron', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('returns success:false when all queue batches fail', async () => {
+    // Arrange: Mock sections to check
+    const mockSections = Array.from({ length: 250 }, (_, i) => ({
+      class_nbr: String(10000 + i),
+      term: '2261',
+    }));
+    vi.mocked(getSectionsToCheck).mockResolvedValue(mockSections);
+
+    // Arrange: Mock queue to always fail (simulating Cloudflare Queue outage)
+    const { env } = await import('cloudflare:workers');
+    vi.mocked(env.PICKMYCLASS_QUEUE.sendBatch).mockRejectedValue(
+      new Error('Queue service unavailable')
+    );
+
+    // Act
+    const response = await GET(createRequest('Bearer test-cron-secret'));
+    const data = await response.json();
+
+    // Assert: Should return success:false when batches fail
+    const responseData = data as {
+      success: boolean;
+      batches_failed: number;
+      batches_total: number;
+    };
+    expect(responseData.success).toBe(false);
+    expect(responseData.batches_failed).toBeGreaterThan(0);
+    expect(responseData.batches_total).toBeGreaterThan(0);
+  });
+
+  it('returns success:true when all queue batches succeed', async () => {
+    // Arrange: Mock sections to check
+    const mockSections = Array.from({ length: 50 }, (_, i) => ({
+      class_nbr: String(10000 + i),
+      term: '2261',
+    }));
+    vi.mocked(getSectionsToCheck).mockResolvedValue(mockSections);
+
+    // Arrange: Mock queue to succeed
+    const { env } = await import('cloudflare:workers');
+    vi.mocked(env.PICKMYCLASS_QUEUE.sendBatch).mockResolvedValue(undefined);
+
+    // Act
+    const response = await GET(createRequest('Bearer test-cron-secret'));
+    const data = await response.json();
+
+    // Assert: Should return success:true when all batches succeed
+    const responseData = data as {
+      success: boolean;
+      batches_failed: number;
+      sections_enqueued: number;
+    };
+    expect(responseData.success).toBe(true);
+    expect(responseData.batches_failed).toBe(0);
+    expect(responseData.sections_enqueued).toBe(50);
+  });
+
+  it('returns success:false with partial failure info when some batches fail', async () => {
+    // Arrange: Mock sections to check (need at least 2 batches)
+    const mockSections = Array.from({ length: 150 }, (_, i) => ({
+      class_nbr: String(10000 + i),
+      term: '2261',
+    }));
+    vi.mocked(getSectionsToCheck).mockResolvedValue(mockSections);
+
+    // Arrange: Mock queue to fail only the second batch
+    const { env } = await import('cloudflare:workers');
+    let callCount = 0;
+    vi.mocked(env.PICKMYCLASS_QUEUE.sendBatch).mockImplementation(() => {
+      callCount++;
+      if (callCount === 2) {
+        return Promise.reject(new Error('Transient error'));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    // Act
+    const response = await GET(createRequest('Bearer test-cron-secret'));
+    const data = await response.json();
+
+    // Assert: Should return success:false when there are any failed batches
+    const responseData = data as {
+      success: boolean;
+      batches_failed: number;
+      batches_total: number;
+    };
+    expect(responseData.success).toBe(false);
+    expect(responseData.batches_failed).toBe(1);
+    expect(responseData.batches_total).toBe(2);
+  });
+});


### PR DESCRIPTION
Fixes #160

## Summary
The cron endpoint was always returning success:true regardless of whether queue.sendBatch() calls failed. This caused silent failures during Cloudflare Queue outages.

## Changes
- Check failedBatches.length > 0 and set success accordingly
- Return HTTP 207 Multi-Status for partial failures  
- Added comprehensive tests for success/failure scenarios

## TDD
- Red: Tests failed showing success:true when it should be false
- Green: Implemented fix to check failedBatches.length
- Refactor: Proper status code handling

## Validation
- bun run test:run: 352 tests passed
- bun run type-check: No errors
- bun run lint: No errors

## Risk
Low - Simple boolean logic change with comprehensive test coverage.

## Auto-merge readiness
Ready for review and merge.