### PR TITLE
fix: trigger notifications on first observed open state

### DIFF
--- a/app/api/queue/process-section/route.ts
+++ b/app/api/queue/process-section/route.ts
@@ -121,11 +121,11 @@ export async function POST(request: NextRequest) {
       if (error instanceof AuthError || error instanceof NotFoundError) {
         console.error(
           `[Queue-Processor] Non-retryable error for section ${class_nbr}:`,
-          error.message
+          (error as Error).message
         );
         // Return 200 so the queue consumer acks the message (non-retryable)
         return NextResponse.json(
-          { success: false, error: error.message, retryable: false },
+          { success: false, error: (error as Error).message, retryable: false },
           { status: 200 }
         );
       }
@@ -135,14 +135,17 @@ export async function POST(request: NextRequest) {
         );
         // Return non-2xx so the queue consumer retries (uses wrangler retry_delay: 60s)
         return NextResponse.json(
-          { success: false, error: error.message, retryable: true },
+          { success: false, error: (error as Error).message, retryable: true },
           { status: 429 }
         );
       }
       if (error instanceof ApiError) {
-        console.error(`[Queue-Processor] API error for section ${class_nbr}:`, error.message);
+        console.error(
+          `[Queue-Processor] API error for section ${class_nbr}:`,
+          (error as Error).message
+        );
         return NextResponse.json(
-          { success: false, error: error.message, retryable: true },
+          { success: false, error: (error as Error).message, retryable: true },
           { status: 502 }
         );
       }
@@ -162,29 +165,31 @@ export async function POST(request: NextRequest) {
       return nonReserved ?? totalAvailable;
     };
 
-    if (oldState) {
-      const oldOpenSeats = getOpenSeats(oldState.non_reserved_seats, oldState.seats_available);
-      const newOpenSeats = getOpenSeats(newData.non_reserved_seats, newData.seats_available ?? 0);
+    // When oldState is null (first observation), treat baseline as:
+    // - seats_available = 0 (full)
+    // - instructor_name = 'Staff'
+    // This ensures notifications trigger on first observed open state
+    const oldOpenSeats = oldState
+      ? getOpenSeats(oldState.non_reserved_seats, oldState.seats_available)
+      : 0;
+    const oldInstructor = oldState?.instructor_name ?? 'Staff';
 
-      if (oldOpenSeats > 0 && newOpenSeats === 0) {
-        seatsFilled = true;
-      }
+    const newOpenSeats = getOpenSeats(newData.non_reserved_seats, newData.seats_available ?? 0);
 
-      if (oldOpenSeats === 0 && newOpenSeats > 0) {
-        seatBecameAvailable = true;
-        console.log(`[Queue-Processor] 🎉 Seat available in ${class_nbr}: ${newOpenSeats} seats`);
-      }
+    if (oldOpenSeats > 0 && newOpenSeats === 0) {
+      seatsFilled = true;
+    }
 
-      if (
-        oldState.instructor_name === 'Staff' &&
-        newData.instructor &&
-        newData.instructor !== 'Staff'
-      ) {
-        instructorAssigned = true;
-        console.log(
-          `[Queue-Processor] 👨‍🏫 Instructor assigned in ${class_nbr}: ${newData.instructor}`
-        );
-      }
+    if (oldOpenSeats === 0 && newOpenSeats > 0) {
+      seatBecameAvailable = true;
+      console.log(`[Queue-Processor] 🎉 Seat available in ${class_nbr}: ${newOpenSeats} seats`);
+    }
+
+    if (oldInstructor === 'Staff' && newData.instructor && newData.instructor !== 'Staff') {
+      instructorAssigned = true;
+      console.log(
+        `[Queue-Processor] 👨‍🏫 Instructor assigned in ${class_nbr}: ${newData.instructor}`
+      );
     }
 
     // Step 3A: Reset notifications if seats filled

--- a/tests/integration/api/process-section.test.ts
+++ b/tests/integration/api/process-section.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ValidationIssueDetail } from '@/lib/api/validation';
 
 // Mock Cloudflare Workers env - must use factory function for hoisting
@@ -20,7 +20,81 @@ function createRequest(body: string, authHeader?: string): NextRequest {
   });
 }
 
+// Mock Supabase service client
+const mockFrom = vi.fn();
+const mockRpc = vi.fn();
+
+vi.mock('@/lib/supabase/service', () => ({
+  getServiceClient: vi.fn(() => ({
+    from: mockFrom,
+    rpc: mockRpc,
+  })),
+}));
+
+// Mock ASU API client
+const mockFetchClassFromASU = vi.fn();
+vi.mock('@/lib/asu/api', () => ({
+  fetchClassFromASU: (...args: unknown[]) => mockFetchClassFromASU(...args),
+  NotFoundError: class NotFoundError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'NotFoundError';
+    }
+  },
+  AuthError: class AuthError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'AuthError';
+    }
+  },
+  ApiError: class ApiError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  },
+  RateLimitError: class RateLimitError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'RateLimitError';
+    }
+  },
+}));
+
+// Mock email sending
+const mockSendBatchEmailsOptimized = vi.fn();
+vi.mock('@/lib/email/resend', () => ({
+  sendBatchEmailsOptimized: (...args: unknown[]) => mockSendBatchEmailsOptimized(...args),
+}));
+
+// Mock DB queries
+const mockTryRecordNotificationsBatch = vi.fn();
+const mockResetNotificationsForSection = vi.fn();
+const mockDeleteNotificationRecords = vi.fn();
+
+vi.mock('@/lib/db/queries', () => ({
+  tryRecordNotificationsBatch: (...args: unknown[]) => mockTryRecordNotificationsBatch(...args),
+  resetNotificationsForSection: (...args: unknown[]) => mockResetNotificationsForSection(...args),
+  deleteNotificationRecords: (...args: unknown[]) => mockDeleteNotificationRecords(...args),
+}));
+
 describe('POST /api/queue/process-section', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: no existing state (simulates first observation)
+    mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+        })),
+      })),
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    });
+    mockRpc.mockResolvedValue({ data: [], error: null });
+    mockSendBatchEmailsOptimized.mockResolvedValue([]);
+    mockTryRecordNotificationsBatch.mockResolvedValue(new Set());
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -67,5 +141,201 @@ describe('POST /api/queue/process-section', () => {
     expect(data.retryable).toBe(false);
     expect(data.details).toBeDefined();
     expect(data.details.length).toBeGreaterThan(0);
+  });
+
+  describe('change detection with null oldState (first observation)', () => {
+    it('should detect seatBecameAvailable when oldState is null and seats are available', async () => {
+      // Mock ASU API to return class with open seats
+      mockFetchClassFromASU.mockResolvedValue({
+        subject: 'CSE',
+        catalog_nbr: '110',
+        title: 'Intro to Programming',
+        instructor: 'Dr. Smith',
+        seats_available: 5,
+        seats_capacity: 30,
+        non_reserved_seats: null,
+        location: 'Online',
+        meeting_times: 'MWF 9:00-9:50',
+      });
+
+      // Mock watcher exists
+      mockRpc.mockResolvedValue({
+        data: [{ user_id: 'user-1', email: 'test@example.com', watch_id: 'watch-1' }],
+        error: null,
+      });
+
+      // Mock notification recording to succeed for both types
+      mockTryRecordNotificationsBatch
+        .mockResolvedValueOnce(new Set(['watch-1'])) // seat_available
+        .mockResolvedValueOnce(new Set(['watch-1'])); // instructor_assigned
+
+      // Mock email sending
+      mockSendBatchEmailsOptimized.mockResolvedValue([
+        { success: true, id: 'email-1' },
+        { success: true, id: 'email-2' },
+      ]);
+
+      const response = await POST(
+        createRequest(
+          JSON.stringify({ class_nbr: '12345', term: '2261' }),
+          'Bearer test-cron-secret'
+        )
+      );
+
+      const data = (await response.json()) as {
+        success: boolean;
+        changes_detected: {
+          seat_became_available: boolean;
+          instructor_assigned: boolean;
+        };
+        emails_sent: number;
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.changes_detected.seat_became_available).toBe(true);
+      expect(data.changes_detected.instructor_assigned).toBe(true); // Staff -> Dr. Smith
+      expect(data.emails_sent).toBe(2); // Both notifications
+    });
+
+    it('should detect instructorAssigned when oldState is null and instructor is not Staff', async () => {
+      // Mock ASU API to return class with assigned instructor (not Staff)
+      mockFetchClassFromASU.mockResolvedValue({
+        subject: 'CSE',
+        catalog_nbr: '110',
+        title: 'Intro to Programming',
+        instructor: 'Dr. Johnson', // Not 'Staff'
+        seats_available: 0, // No seats available
+        seats_capacity: 30,
+        non_reserved_seats: null,
+        location: 'Online',
+        meeting_times: 'MWF 9:00-9:50',
+      });
+
+      // Mock watcher exists
+      mockRpc.mockResolvedValue({
+        data: [{ user_id: 'user-1', email: 'test@example.com', watch_id: 'watch-1' }],
+        error: null,
+      });
+
+      // Mock notification recording to succeed
+      mockTryRecordNotificationsBatch.mockResolvedValue(new Set(['watch-1']));
+
+      // Mock email sending
+      mockSendBatchEmailsOptimized.mockResolvedValue([{ success: true, id: 'email-1' }]);
+
+      const response = await POST(
+        createRequest(
+          JSON.stringify({ class_nbr: '12345', term: '2261' }),
+          'Bearer test-cron-secret'
+        )
+      );
+
+      const data = (await response.json()) as {
+        success: boolean;
+        changes_detected: {
+          seat_became_available: boolean;
+          instructor_assigned: boolean;
+        };
+        emails_sent: number;
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.changes_detected.seat_became_available).toBe(false); // 0 seats available
+      expect(data.changes_detected.instructor_assigned).toBe(true); // Staff -> Dr. Johnson
+      expect(data.emails_sent).toBe(1);
+    });
+
+    it('should detect both changes when oldState is null and both conditions are met', async () => {
+      // Mock ASU API to return class with open seats and assigned instructor
+      mockFetchClassFromASU.mockResolvedValue({
+        subject: 'CSE',
+        catalog_nbr: '110',
+        title: 'Intro to Programming',
+        instructor: 'Dr. Smith', // Not 'Staff'
+        seats_available: 5,
+        seats_capacity: 30,
+        non_reserved_seats: null,
+        location: 'Online',
+        meeting_times: 'MWF 9:00-9:50',
+      });
+
+      // Mock watcher exists
+      mockRpc.mockResolvedValue({
+        data: [{ user_id: 'user-1', email: 'test@example.com', watch_id: 'watch-1' }],
+        error: null,
+      });
+
+      // Mock notification recording to succeed for both types
+      mockTryRecordNotificationsBatch
+        .mockResolvedValueOnce(new Set(['watch-1'])) // seat_available
+        .mockResolvedValueOnce(new Set(['watch-1'])); // instructor_assigned
+
+      // Mock email sending
+      mockSendBatchEmailsOptimized.mockResolvedValue([
+        { success: true, id: 'email-1' },
+        { success: true, id: 'email-2' },
+      ]);
+
+      const response = await POST(
+        createRequest(
+          JSON.stringify({ class_nbr: '12345', term: '2261' }),
+          'Bearer test-cron-secret'
+        )
+      );
+
+      const data = (await response.json()) as {
+        success: boolean;
+        changes_detected: {
+          seat_became_available: boolean;
+          instructor_assigned: boolean;
+        };
+        emails_sent: number;
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.changes_detected.seat_became_available).toBe(true);
+      expect(data.changes_detected.instructor_assigned).toBe(true);
+      expect(data.emails_sent).toBe(2);
+    });
+
+    it('should not trigger notifications when seats are 0 and instructor is Staff with null oldState', async () => {
+      // Mock ASU API to return class with no seats and Staff instructor
+      mockFetchClassFromASU.mockResolvedValue({
+        subject: 'CSE',
+        catalog_nbr: '110',
+        title: 'Intro to Programming',
+        instructor: 'Staff',
+        seats_available: 0,
+        seats_capacity: 30,
+        non_reserved_seats: null,
+        location: 'Online',
+        meeting_times: 'MWF 9:00-9:50',
+      });
+
+      const response = await POST(
+        createRequest(
+          JSON.stringify({ class_nbr: '12345', term: '2261' }),
+          'Bearer test-cron-secret'
+        )
+      );
+
+      const data = (await response.json()) as {
+        success: boolean;
+        changes_detected: {
+          seat_became_available: boolean;
+          instructor_assigned: boolean;
+        };
+        emails_sent: number;
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.changes_detected.seat_became_available).toBe(false);
+      expect(data.changes_detected.instructor_assigned).toBe(false);
+      expect(data.emails_sent).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Fixes #161

## Summary
Fixed bug in process-section route where notifications were not triggered on the first observation of a class. When  is  (no previous state exists), the change detection logic now treats the baseline as:
-  (full)
- 

This ensures that when a user adds a watch for a class that already has open seats or an assigned instructor, they receive notifications immediately instead of waiting for a fill→reopen cycle.

## TDD
- **Red**: Added 4 new tests for null oldState scenarios - 3 failed as expected
  - 
  -   
  - 
- **Green**: Modified change detection logic to handle null oldState with baseline defaults
- **Refactor**: Cleaned up TypeScript type assertions in error handling

## Validation
- All 356 tests pass (25 test files)
- Biome lint/format pass
- TypeScript type-check pass
- No breaking changes to existing behavior

## Risk
- **Low**: Change is additive and scoped only to the null oldState case
- Existing behavior with actual oldState data remains unchanged
- Comprehensive test coverage added

## Auto-merge readiness
- Ready: All checks pass, tests added, low risk change

## Files Changed
-  - Fixed change detection logic
-  - Added 4 comprehensive tests