### PR TITLE
fix(proxy): add security headers on 3xx redirect responses

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -214,7 +214,9 @@ export async function proxy(request: NextRequest) {
       const url = request.nextUrl.clone();
       url.pathname = '/login';
       url.searchParams.set('error', 'account_disabled');
-      return NextResponse.redirect(url);
+      const redirectResponse = NextResponse.redirect(url);
+      addSecurityHeaders(redirectResponse, isDevelopment);
+      return redirectResponse;
     }
   }
 
@@ -228,7 +230,9 @@ export async function proxy(request: NextRequest) {
     if (!isAllowedPath && pathname !== '/') {
       const url = request.nextUrl.clone();
       url.pathname = '/verify-email';
-      return NextResponse.redirect(url);
+      const redirectResponse = NextResponse.redirect(url);
+      addSecurityHeaders(redirectResponse, isDevelopment);
+      return redirectResponse;
     }
   }
 
@@ -240,7 +244,9 @@ export async function proxy(request: NextRequest) {
   if (!user && isProtectedRoute) {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
-    return NextResponse.redirect(url);
+    const redirectResponse = NextResponse.redirect(url);
+    addSecurityHeaders(redirectResponse, isDevelopment);
+    return redirectResponse;
   }
 
   // Redirect authenticated users from auth pages to their dashboard
@@ -253,7 +259,9 @@ export async function proxy(request: NextRequest) {
     if (pathname !== redirectPath) {
       const url = request.nextUrl.clone();
       url.pathname = redirectPath;
-      return NextResponse.redirect(url);
+      const redirectResponse = NextResponse.redirect(url);
+      addSecurityHeaders(redirectResponse, isDevelopment);
+      return redirectResponse;
     }
   }
 
@@ -266,7 +274,9 @@ export async function proxy(request: NextRequest) {
     if (userProfile?.is_admin) {
       const url = request.nextUrl.clone();
       url.pathname = '/admin';
-      return NextResponse.redirect(url);
+      const redirectResponse = NextResponse.redirect(url);
+      addSecurityHeaders(redirectResponse, isDevelopment);
+      return redirectResponse;
     }
   }
 

--- a/tests/integration/middleware.test.ts
+++ b/tests/integration/middleware.test.ts
@@ -482,6 +482,92 @@ describe('proxy', () => {
       expect(csp).toContain("default-src 'self'");
       expect(csp).toContain("frame-ancestors 'none'");
     });
+
+    it('should add security headers on redirect responses (unauthenticated to protected route)', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+      const request = createRequest('/dashboard');
+      const response = await proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe('http://localhost:3000/login');
+      // Security headers should be present on redirects
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+      expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+      expect(response.headers.get('Strict-Transport-Security')).toBe(
+        'max-age=31536000; includeSubDomains'
+      );
+    });
+
+    it('should add security headers on redirect responses (disabled account)', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: mockAuthenticatedUser },
+        error: null,
+      });
+      mockSingle.mockResolvedValue({ data: mockDisabledProfile, error: null });
+      mockSignOut.mockResolvedValue({ error: null });
+
+      const request = createRequest('/dashboard');
+      const response = await proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toContain('/login');
+      // Security headers should be present on redirects
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    });
+
+    it('should add security headers on redirect responses (unverified user)', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: mockUnverifiedUser },
+        error: null,
+      });
+      mockSingle.mockResolvedValue({ data: mockRegularProfile, error: null });
+
+      const request = createRequest('/dashboard');
+      const response = await proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe('http://localhost:3000/verify-email');
+      // Security headers should be present on redirects
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    });
+
+    it('should add security headers on redirect responses (auth page to dashboard)', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: mockAuthenticatedUser },
+        error: null,
+      });
+      mockSingle.mockResolvedValue({ data: mockRegularProfile, error: null });
+
+      const request = createAuthenticatedRequest('/login');
+      const response = await proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe('http://localhost:3000/dashboard');
+      // Security headers should be present on redirects
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    });
+
+    it('should add security headers on redirect responses (dashboard to admin)', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: mockAuthenticatedUser },
+        error: null,
+      });
+      mockSingle.mockResolvedValue({ data: mockAdminProfile, error: null });
+
+      const request = createRequest('/dashboard');
+      const response = await proxy(request);
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe('http://localhost:3000/admin');
+      // Security headers should be present on redirects
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    });
   });
 
   describe('profile fetch errors', () => {


### PR DESCRIPTION
Fixes #162

## Summary
Security headers were missing on all 3xx redirect responses in the proxy middleware. This is a security vulnerability because HSTS headers on redirects protect against MITM attacks—a user's first request getting a redirect without HSTS could be intercepted.

## Changes
- Added `addSecurityHeaders()` call on all 5 `NextResponse.redirect()` returns:
  - Disabled account redirect to /login
  - Unverified user redirect to /verify-email
  - Unauthenticated user redirect to /login
  - Auth page to dashboard redirect
  - Dashboard to admin redirect
- Added 5 regression tests for security headers on redirect responses

## TDD Evidence
- **Red**: Added tests for security headers on redirects → 5 tests failed (headers were null)
- **Green**: Fixed proxy.ts to call `addSecurityHeaders()` on all redirect responses → all 43 middleware tests pass
- **Refactor**: No refactoring needed - change is minimal and focused

## Validation
- All 361 tests passing (up from 356, +5 new tests)
- `bun run lint` - passed
- `bun run type-check` - passed
- `bun run test:run` - passed

## Risk Assessment
**Low** - This is a focused security fix with regression tests. The change adds headers to redirect responses without modifying any logic. All existing tests pass.

## Auto-merge Readiness
- [x] All CI checks passing
- [x] Regression tests added
- [x] No breaking changes
- [x] Security vulnerability fixed