### PR TITLE
fix(auth): check is_disabled before issuing session on login

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -47,6 +47,20 @@ export async function POST(request: NextRequest) {
       password,
     });
 
+    // Check if user account is disabled before proceeding
+    if (data?.user) {
+      const { data: profile } = await supabase
+        .from('user_profiles')
+        .select('is_disabled')
+        .eq('user_id', data.user.id)
+        .single();
+
+      if (profile?.is_disabled) {
+        await supabase.auth.signOut();
+        return NextResponse.json({ error: 'Account has been disabled' }, { status: 403 });
+      }
+    }
+
     if (error || !data?.user) {
       await incrementFailedAttempts(email);
       const updatedStatus = await checkLockoutStatus(email);

--- a/tests/integration/api/login.test.ts
+++ b/tests/integration/api/login.test.ts
@@ -32,13 +32,25 @@ vi.mock('@/lib/auth/lockout', () => ({
 
 // Mock the Supabase server client
 const mockSignInWithPassword = vi.fn();
+const mockSignOut = vi.fn();
+
+// Default mock for user_profiles query (non-disabled user)
+const mockSingle = vi.fn().mockResolvedValue({
+  data: { is_disabled: false },
+  error: null,
+});
+const mockEq = vi.fn().mockReturnValue({ single: mockSingle });
+const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+const mockFrom = vi.fn().mockReturnValue({ select: mockSelect });
 
 vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(() =>
     Promise.resolve({
       auth: {
         signInWithPassword: mockSignInWithPassword,
+        signOut: mockSignOut,
       },
+      from: mockFrom,
     })
   ),
 }));
@@ -70,6 +82,12 @@ describe('POST /api/auth/login', () => {
       isLocked: false,
       attempts: 0,
       lockedUntil: null,
+    });
+
+    // Reset profile query mock to return non-disabled user by default
+    mockSingle.mockResolvedValue({
+      data: { is_disabled: false },
+      error: null,
     });
   });
 
@@ -295,6 +313,80 @@ describe('POST /api/auth/login', () => {
 
       expect(response.status).toBe(500);
       expect(data.error).toBe('Failed to sign in');
+    });
+  });
+
+  describe('disabled account', () => {
+    it('should return 403 when user is disabled', async () => {
+      // Mock signInWithPassword to succeed (user has valid credentials)
+      mockSignInWithPassword.mockResolvedValue({
+        data: { user: { id: 'user-123' } },
+        error: null,
+      });
+
+      // Mock the from/single chain for checking user profile
+      const mockSingle = vi.fn().mockResolvedValue({
+        data: { is_disabled: true },
+        error: null,
+      });
+      const mockEq = vi.fn().mockReturnValue({ single: mockSingle });
+      const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+      const mockFrom = vi.fn().mockReturnValue({ select: mockSelect });
+
+      // Mock the signOut function
+      const mockSignOut = vi.fn().mockResolvedValue({ error: null });
+
+      // Override the createClient mock for this test to include from() and signOut()
+      const { createClient } = await import('@/lib/supabase/server');
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          signInWithPassword: mockSignInWithPassword,
+          signOut: mockSignOut,
+        },
+        from: mockFrom,
+      } as never);
+
+      const request = createRequest({ email: 'disabled@example.com', password: 'validpassword' });
+      const response = await POST(request);
+      const data = await parseResponse(response);
+
+      expect(response.status).toBe(403);
+      expect(data.error).toBe('Account has been disabled');
+      expect(mockFrom).toHaveBeenCalledWith('user_profiles');
+      expect(mockSignOut).toHaveBeenCalled();
+    });
+
+    it('should allow login for non-disabled users', async () => {
+      // Mock signInWithPassword to succeed
+      mockSignInWithPassword.mockResolvedValue({
+        data: { user: { id: 'user-456' } },
+        error: null,
+      });
+
+      // Mock the from/single chain to return non-disabled user
+      const mockSingle = vi.fn().mockResolvedValue({
+        data: { is_disabled: false },
+        error: null,
+      });
+      const mockEq = vi.fn().mockReturnValue({ single: mockSingle });
+      const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+      const mockFrom = vi.fn().mockReturnValue({ select: mockSelect });
+
+      const { createClient } = await import('@/lib/supabase/server');
+      vi.mocked(createClient).mockResolvedValue({
+        auth: {
+          signInWithPassword: mockSignInWithPassword,
+        },
+        from: mockFrom,
+      } as never);
+
+      const request = createRequest({ email: 'active@example.com', password: 'validpassword' });
+      const response = await POST(request);
+      const data = await parseResponse(response);
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(mockFrom).toHaveBeenCalledWith('user_profiles');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #163 - Disabled users could re-authenticate indefinitely, burning server resources.

## Problem

The login API (`app/api/auth/login/route.ts`) called `signInWithPassword` without checking `is_disabled`. A disabled user would:
1. Get a valid session cookie from login
2. Make a request → proxy.ts detects `is_disabled` → signs them out → redirects to login
3. Repeat step 1 (loop indefinitely)

## Solution

Check `is_disabled` in the login route immediately after successful authentication. If the account is disabled:
1. Call `supabase.auth.signOut()` to invalidate the session
2. Return 403 with message "Account has been disabled"

## Changes

- **app/api/auth/login/route.ts**: Added check for `is_disabled` after `signInWithPassword`
- **tests/integration/api/login.test.ts**: Added 2 tests for disabled account handling

## Validation

- **TDD Evidence**: 
  - Red: 2 new tests failed (expected 403 for disabled user, got 200)
  - Green: All 16 login tests pass, 383 total tests pass
- **Lint**: Biome clean
- **Type check**: tsc --noEmit clean

## Acceptance Criteria

- [x] Disabled users receive 403 on login attempt
- [x] Non-disabled users can log in normally
- [x] Server resources no longer wasted on disabled user re-auth loops
- [x] 100% of new code covered by tests