### PR TITLE
fix(frontend): await async deletion before closing dialog

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@tailwindcss/postcss": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -565,6 +566,8 @@
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
 
     "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/components/ClassWatchCard.tsx
+++ b/components/ClassWatchCard.tsx
@@ -115,9 +115,11 @@ export function ClassWatchCard({ watch, classState, onDelete, onRestore }: Class
     try {
       await onDelete(watch.id);
       toast.success('Class watch removed');
+      setShowDeleteConfirm(false);
     } catch (error) {
       console.error('Failed to delete watch:', error);
       toast.error('Failed to delete watch. Please try again.');
+    } finally {
       setIsDeleting(false);
     }
   };

--- a/components/DeleteConfirmDialog.tsx
+++ b/components/DeleteConfirmDialog.tsx
@@ -14,7 +14,7 @@ import {
 interface DeleteConfirmDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConfirm: () => void;
+  onConfirm: () => Promise<void>;
   title: string;
   description: string;
   confirmText?: string;
@@ -32,9 +32,14 @@ export function DeleteConfirmDialog({
   cancelText = 'Cancel',
   isDeleting = false,
 }: DeleteConfirmDialogProps) {
-  const handleConfirm = () => {
-    onConfirm();
-    onOpenChange(false);
+  const handleConfirm = async () => {
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch {
+      // Error handling is done by the parent (toast, etc.)
+      // Keep dialog open on error
+    }
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/tests/unit/components/ClassWatchCard.test.tsx
+++ b/tests/unit/components/ClassWatchCard.test.tsx
@@ -1,0 +1,153 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ClassWatchCard } from '@/components/ClassWatchCard';
+import type { ClassStateRow, ClassWatchRow } from '@/lib/types/class-watch';
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock framer-motion
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: { children: React.ReactNode }) => (
+      <div {...props}>{children}</div>
+    ),
+    button: ({ children, ...props }: { children: React.ReactNode }) => (
+      <button {...props}>{children}</button>
+    ),
+  },
+}));
+
+const mockWatch: ClassWatchRow = {
+  id: 'watch-123',
+  user_id: 'user-123',
+  term: '2241',
+  subject: 'CSE',
+  catalog_nbr: '110',
+  class_nbr: '12345',
+  created_at: new Date().toISOString(),
+};
+
+const mockClassState: ClassStateRow = {
+  id: 'state-123',
+  term: '2241',
+  subject: 'CSE',
+  catalog_nbr: '110',
+  class_nbr: '12345',
+  seats_available: 5,
+  seats_capacity: 30,
+  non_reserved_seats: null,
+  title: 'Introduction to Programming',
+  instructor_name: 'Dr. Smith',
+  location: 'TBD',
+  meeting_times: 'MWF 10:00-11:00',
+  last_checked_at: new Date().toISOString(),
+  last_changed_at: new Date().toISOString(),
+};
+
+describe('ClassWatchCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('delete functionality', () => {
+    it('should reset isDeleting state after successful delete', async () => {
+      const user = userEvent.setup();
+      let resolveDelete: () => void;
+      const deletePromise = new Promise<void>((resolve) => {
+        resolveDelete = resolve;
+      });
+
+      const onDelete = vi.fn().mockReturnValue(deletePromise);
+
+      render(<ClassWatchCard watch={mockWatch} classState={mockClassState} onDelete={onDelete} />);
+
+      // Open delete dialog
+      const deleteButton = screen.getByRole('button', {
+        name: /stop watching/i,
+      });
+      await user.click(deleteButton);
+
+      // Dialog should be open - click confirm
+      const confirmButton = screen.getByRole('button', { name: /stop watching/i });
+
+      // Click in act() since it triggers state changes
+      await act(async () => {
+        await user.click(confirmButton);
+      });
+
+      // onDelete should be called
+      expect(onDelete).toHaveBeenCalledTimes(1);
+
+      // Resolve the delete promise
+      await act(async () => {
+        resolveDelete();
+        await deletePromise;
+      });
+
+      // Wait a bit for state updates
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // The delete button should be enabled again (isDeleting reset)
+      // We verify this by checking the original button is not disabled
+      const deleteButtons = screen.queryAllByRole('button', {
+        name: /stop watching/i,
+      });
+
+      // If dialog is closed and card is still rendered, the button should be enabled
+      for (const button of deleteButtons) {
+        expect(button).not.toBeDisabled();
+      }
+    });
+
+    it('should reset isDeleting state after failed delete', async () => {
+      const user = userEvent.setup();
+      let rejectDelete: (error: Error) => void;
+      const deletePromise = new Promise<void>((_, reject) => {
+        rejectDelete = reject;
+      });
+
+      const onDelete = vi.fn().mockReturnValue(deletePromise);
+
+      render(<ClassWatchCard watch={mockWatch} classState={mockClassState} onDelete={onDelete} />);
+
+      // Open delete dialog
+      const deleteButton = screen.getByRole('button', {
+        name: /stop watching/i,
+      });
+      await user.click(deleteButton);
+
+      // Click confirm
+      const confirmButton = screen.getByRole('button', { name: /stop watching/i });
+
+      await act(async () => {
+        await user.click(confirmButton);
+      });
+
+      // Reject the delete promise
+      await act(async () => {
+        rejectDelete(new Error('Delete failed'));
+        try {
+          await deletePromise;
+        } catch {
+          // Expected
+        }
+      });
+
+      // Wait for state updates
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // After error, the delete button in the dialog should be re-enabled
+      const dialogDeleteButton = screen.getByRole('button', { name: /stop watching/i });
+      await waitFor(() => {
+        expect(dialogDeleteButton).not.toBeDisabled();
+      });
+    });
+  });
+});

--- a/tests/unit/components/DeleteConfirmDialog.test.tsx
+++ b/tests/unit/components/DeleteConfirmDialog.test.tsx
@@ -1,0 +1,119 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeleteConfirmDialog } from '@/components/DeleteConfirmDialog';
+
+describe('DeleteConfirmDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('async deletion handling', () => {
+    it('should wait for async onConfirm to complete before closing dialog', async () => {
+      const user = userEvent.setup();
+      let resolveDelete: () => void;
+      const deletePromise = new Promise<void>((resolve) => {
+        resolveDelete = resolve;
+      });
+
+      const onConfirm = vi.fn().mockReturnValue(deletePromise);
+      const onOpenChange = vi.fn();
+
+      render(
+        <DeleteConfirmDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          onConfirm={onConfirm}
+          title="Delete Item?"
+          description="This will delete the item"
+        />
+      );
+
+      // Click the delete button
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await user.click(deleteButton);
+
+      // onConfirm should be called
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+
+      // But onOpenChange should NOT be called yet (async operation pending)
+      expect(onOpenChange).not.toHaveBeenCalled();
+
+      // Now resolve the async operation
+      await act(async () => {
+        resolveDelete();
+        await deletePromise;
+      });
+
+      // NOW onOpenChange should be called with false to close dialog
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('should not close dialog if onConfirm throws error', async () => {
+      const user = userEvent.setup();
+      const onConfirm = vi.fn().mockRejectedValue(new Error('Delete failed'));
+      const onOpenChange = vi.fn();
+
+      render(
+        <DeleteConfirmDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          onConfirm={onConfirm}
+          title="Delete Item?"
+          description="This will delete the item"
+        />
+      );
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+
+      await user.click(deleteButton);
+
+      // Wait for async operation to complete (and fail)
+      await act(async () => {
+        // Give time for the promise to reject
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      // onConfirm should be called
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+
+      // Dialog should NOT close on error
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it('should disable buttons while isDeleting is true', async () => {
+      render(
+        <DeleteConfirmDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onConfirm={vi.fn()}
+          title="Delete Item?"
+          description="This will delete the item"
+          isDeleting={true}
+        />
+      );
+
+      const deleteButton = screen.getByRole('button', { name: /deleting/i });
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+
+      expect(deleteButton).toBeDisabled();
+      expect(cancelButton).toBeDisabled();
+    });
+
+    it('should show "Deleting..." text while isDeleting is true', async () => {
+      render(
+        <DeleteConfirmDialog
+          open={true}
+          onOpenChange={vi.fn()}
+          onConfirm={vi.fn()}
+          title="Delete Item?"
+          description="This will delete the item"
+          isDeleting={true}
+          confirmText="Remove"
+        />
+      );
+
+      expect(screen.getByText('Deleting...')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #172 - DeleteConfirmDialog closes before async deletion completes.

## Changes

### DeleteConfirmDialog.tsx
- Changed `onConfirm` type from `() => void` to `() => Promise<void>` to properly handle async operations
- Made `handleConfirm` async and added `await onConfirm()` before closing dialog
- Added try-catch block to keep dialog open when deletion fails

### ClassWatchCard.tsx
- Moved `setIsDeleting(false)` to a `finally` block to ensure state is reset on both success and error
- Added `setShowDeleteConfirm(false)` on successful delete to close the dialog

## Testing

TDD approach used:
1. Wrote failing tests exposing the bugs
2. Implemented minimal fixes to make tests pass
3. All 397 tests passing

### New Tests
- `DeleteConfirmDialog.test.tsx`: 4 tests covering async deletion, error handling, and UI states
- `ClassWatchCard.test.tsx`: 2 tests verifying isDeleting state reset on success/error

## Verification

- ✅ Biome linting: Clean
- ✅ TypeScript type-check: Clean
- ✅ All 397 tests passing
- ✅ 80%+ coverage maintained

Closes #172