### PR TITLE
fix(auth): use atomic RPC for failed login attempts to prevent race condition

### DIFF
--- a/lib/auth/lockout.ts
+++ b/lib/auth/lockout.ts
@@ -61,39 +61,25 @@ export async function checkLockoutStatus(email: string): Promise<LockoutStatus> 
 
 /**
  * Increment failed login attempts for an email address
- * Locks account after MAX_FAILED_ATTEMPTS
+ * Uses atomic database operation to prevent race conditions
  */
 export async function incrementFailedAttempts(email: string): Promise<void> {
   const supabase = getServiceClient();
   const normalizedEmail = email.toLowerCase();
 
-  const { data: existing } = await supabase
-    .from('failed_login_attempts')
-    .select('*')
-    .eq('email', normalizedEmail)
-    .single();
+  const { error } = await supabase.rpc('increment_failed_attempts', {
+    p_email: normalizedEmail,
+    p_max_attempts: MAX_FAILED_ATTEMPTS,
+    p_lockout_minutes: LOCKOUT_DURATION_MINUTES,
+  });
 
-  const newAttempts = (existing?.attempts ?? 0) + 1;
-  const shouldLock = newAttempts >= MAX_FAILED_ATTEMPTS;
-
-  const updateData: {
-    email: string;
-    attempts: number;
-    last_attempt_at: string;
-    locked_until?: string;
-  } = {
-    email: normalizedEmail,
-    attempts: newAttempts,
-    last_attempt_at: new Date().toISOString(),
-  };
-
-  if (shouldLock) {
-    const lockoutEnd = new Date();
-    lockoutEnd.setMinutes(lockoutEnd.getMinutes() + LOCKOUT_DURATION_MINUTES);
-    updateData.locked_until = lockoutEnd.toISOString();
+  if (error) {
+    throw new Error('Failed to record login attempt');
   }
 
-  await supabase.from('failed_login_attempts').upsert(updateData, { onConflict: 'email' });
+  // RPC returns { attempts: number, locked: boolean }
+  // The database function handles atomic increment and lockout logic
+  return;
 }
 
 /**

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -302,6 +302,10 @@ export type Database = {
           watch_id: string
         }[]
       }
+      increment_failed_attempts: {
+        Args: { p_email: string; p_max_attempts?: number; p_lockout_minutes?: number }
+        Returns: { attempts: number; locked: boolean }
+      }
       record_engagement_open: {
         Args: { p_user_id: string }
         Returns: undefined

--- a/supabase/migrations/20260504120000_add_atomic_increment_failed_attempts.sql
+++ b/supabase/migrations/20260504120000_add_atomic_increment_failed_attempts.sql
@@ -1,0 +1,40 @@
+-- Add atomic function to increment failed login attempts
+-- This fixes the race condition in SELECT-then-UPSERT pattern
+-- by using INSERT ... ON CONFLICT DO UPDATE with atomic increment
+
+CREATE OR REPLACE FUNCTION increment_failed_attempts(
+  p_email TEXT,
+  p_max_attempts INTEGER DEFAULT 5,
+  p_lockout_minutes INTEGER DEFAULT 15
+)
+RETURNS TABLE (attempts INTEGER, locked BOOLEAN)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_attempts INTEGER;
+  v_locked_until TIMESTAMPTZ;
+  v_now TIMESTAMPTZ := NOW();
+BEGIN
+  -- Atomic insert or increment
+  INSERT INTO failed_login_attempts (email, attempts, last_attempt_at, locked_until)
+  VALUES (p_email, 1, v_now, NULL)
+  ON CONFLICT (email) DO UPDATE SET
+    attempts = failed_login_attempts.attempts + 1,
+    last_attempt_at = v_now,
+    -- Lock if attempts reach max (minus 1 because we're about to increment)
+    locked_until = CASE
+      WHEN failed_login_attempts.attempts + 1 >= p_max_attempts
+      THEN v_now + (p_lockout_minutes || ' minutes')::INTERVAL
+      ELSE NULL
+    END
+  RETURNING failed_login_attempts.attempts, failed_login_attempts.locked_until INTO v_attempts, v_locked_until;
+
+  RETURN QUERY SELECT v_attempts, (v_locked_until IS NOT NULL AND v_locked_until > v_now);
+END;
+$$;
+
+-- Revoke default permissions and grant execute only to service_role
+REVOKE EXECUTE ON FUNCTION public.increment_failed_attempts(TEXT, INTEGER, INTEGER) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.increment_failed_attempts(TEXT, INTEGER, INTEGER) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.increment_failed_attempts(TEXT, INTEGER, INTEGER) TO service_role;

--- a/tests/unit/lib/lockout.test.ts
+++ b/tests/unit/lib/lockout.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Create mock chain with proper structure
+// Create mock chain with proper structure including RPC
 const createMockChain = () => {
   const mockData = { current: null as unknown };
   const mockError = { current: null as { message: string; code: string } | null };
+  const mockRpcResult = {
+    current: { data: null, error: null } as { data: unknown; error: unknown },
+  };
 
   const chain = {
     from: vi.fn(),
@@ -11,13 +14,12 @@ const createMockChain = () => {
     eq: vi.fn(),
     single: vi.fn(),
     delete: vi.fn(),
-    upsert: vi.fn(),
+    rpc: vi.fn(),
   };
 
   chain.from.mockReturnValue({
     select: chain.select,
     delete: chain.delete,
-    upsert: chain.upsert,
   });
 
   chain.select.mockReturnValue({
@@ -36,7 +38,7 @@ const createMockChain = () => {
     Promise.resolve({ data: mockData.current, error: mockError.current })
   );
 
-  chain.upsert.mockResolvedValue({ data: null, error: null });
+  chain.rpc.mockImplementation(() => Promise.resolve(mockRpcResult.current));
 
   return {
     ...chain,
@@ -46,9 +48,13 @@ const createMockChain = () => {
     setMockError: (error: { message: string; code: string } | null) => {
       mockError.current = error;
     },
+    setMockRpcResult: (result: { data: unknown; error: unknown }) => {
+      mockRpcResult.current = result;
+    },
     reset: () => {
       mockData.current = null;
       mockError.current = null;
+      mockRpcResult.current = { data: null, error: null };
       vi.clearAllMocks();
     },
   };
@@ -59,6 +65,7 @@ const mockChain = createMockChain();
 vi.mock('@/lib/supabase/service', () => ({
   getServiceClient: vi.fn(() => ({
     from: mockChain.from,
+    rpc: mockChain.rpc,
   })),
 }));
 
@@ -82,7 +89,6 @@ describe('Lockout utilities', () => {
     mockChain.from.mockReturnValue({
       select: mockChain.select,
       delete: mockChain.delete,
-      upsert: mockChain.upsert,
     });
     mockChain.select.mockReturnValue({
       eq: mockChain.eq,
@@ -202,78 +208,48 @@ describe('Lockout utilities', () => {
   });
 
   describe('incrementFailedAttempts', () => {
-    it('should create new record for first failed attempt', async () => {
-      mockChain.setMockData(null);
-      mockChain.setMockError({ message: 'Not found', code: 'PGRST116' });
+    it('should call RPC with normalized email and max attempts', async () => {
+      mockChain.setMockRpcResult({ data: { attempts: 1, locked: false }, error: null });
 
       await incrementFailedAttempts(testEmail);
 
-      expect(mockChain.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: testEmail.toLowerCase(),
-          attempts: 1,
-        }),
-        { onConflict: 'email' }
-      );
-    });
-
-    it('should increment existing attempts', async () => {
-      mockChain.setMockData({ email: testEmail, attempts: 2 });
-      mockChain.setMockError(null);
-
-      await incrementFailedAttempts(testEmail);
-
-      expect(mockChain.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: testEmail.toLowerCase(),
-          attempts: 3,
-        }),
-        { onConflict: 'email' }
-      );
-    });
-
-    it('should lock account when MAX_FAILED_ATTEMPTS reached', async () => {
-      mockChain.setMockData({ email: testEmail, attempts: 4 });
-      mockChain.setMockError(null);
-
-      await incrementFailedAttempts(testEmail);
-
-      expect(mockChain.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: testEmail.toLowerCase(),
-          attempts: 5,
-          locked_until: expect.any(String),
-        }),
-        { onConflict: 'email' }
-      );
-    });
-
-    it('should set last_attempt_at to current time', async () => {
-      mockChain.setMockData(null);
-      mockChain.setMockError({ message: 'Not found', code: 'PGRST116' });
-
-      await incrementFailedAttempts(testEmail);
-
-      expect(mockChain.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          last_attempt_at: new Date().toISOString(),
-        }),
-        { onConflict: 'email' }
-      );
+      expect(mockChain.rpc).toHaveBeenCalledWith('increment_failed_attempts', {
+        p_email: testEmail.toLowerCase(),
+        p_max_attempts: 5,
+        p_lockout_minutes: 15,
+      });
     });
 
     it('should normalize email to lowercase', async () => {
-      mockChain.setMockData(null);
-      mockChain.setMockError({ message: 'Not found', code: 'PGRST116' });
+      mockChain.setMockRpcResult({ data: { attempts: 1, locked: false }, error: null });
 
       await incrementFailedAttempts('TEST@EXAMPLE.COM');
 
-      expect(mockChain.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: 'test@example.com',
-        }),
-        { onConflict: 'email' }
+      expect(mockChain.rpc).toHaveBeenCalledWith('increment_failed_attempts', {
+        p_email: 'test@example.com',
+        p_max_attempts: 5,
+        p_lockout_minutes: 15,
+      });
+    });
+
+    it('should throw error when RPC fails', async () => {
+      mockChain.setMockRpcResult({ data: null, error: { message: 'Database error' } });
+
+      await expect(incrementFailedAttempts(testEmail)).rejects.toThrow(
+        'Failed to record login attempt'
       );
+    });
+
+    it('should handle lockout response from RPC', async () => {
+      mockChain.setMockRpcResult({ data: { attempts: 5, locked: true }, error: null });
+
+      await incrementFailedAttempts(testEmail);
+
+      expect(mockChain.rpc).toHaveBeenCalledWith('increment_failed_attempts', {
+        p_email: testEmail.toLowerCase(),
+        p_max_attempts: 5,
+        p_lockout_minutes: 15,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #168 - Login lockout SELECT-then-UPSERT race allows extra attempts

## Problem

The `incrementFailedAttempts` function in `lib/auth/lockout.ts` used a read-then-write pattern:
1. SELECT existing record
2. Calculate new attempt count in JS
3. UPSERT the new value

This created a race condition where two concurrent requests could:
- Both read the same count (e.g., 2 attempts)
- Both calculate and upsert the same incremented value (3)
- Effectively lose one failed attempt

## Solution

Replaced the SELECT-then-UPSERT with an atomic PostgreSQL RPC function using `INSERT ... ON CONFLICT DO UPDATE`:

```sql
INSERT INTO failed_login_attempts (email, attempts, last_attempt_at, locked_until)
VALUES (p_email, 1, v_now, NULL)
ON CONFLICT (email) DO UPDATE SET
  attempts = failed_login_attempts.attempts + 1,
  last_attempt_at = v_now,
  locked_until = CASE
    WHEN failed_login_attempts.attempts + 1 >= p_max_attempts
    THEN v_now + (p_lockout_minutes || ' minutes')::INTERVAL
    ELSE NULL
  END
```

## Changes

- **SQL Migration**: Add `increment_failed_attempts()` PostgreSQL function with atomic increment logic
- **lib/auth/lockout.ts**: Replace upsert-based implementation with `supabase.rpc()` call
- **lib/supabase/database.types.ts**: Add TypeScript types for new RPC function
- **tests/unit/lib/lockout.test.ts**: Update tests to mock RPC calls

## Validation

- ✅ All 406 tests pass
- ✅ Biome lint passes
- ✅ TypeScript type-check passes
- ✅ TDD cycle: red (tests failed with old impl) → green (tests pass with new impl)

## TDD Evidence

**RED**: Tests expecting RPC calls failed with old implementation (upsert not found)
**GREEN**: All tests pass with new atomic RPC implementation
