### PR TITLE
fix(asu-api): handle empty string enrollment fields without returning NaN

### DIFF
--- a/lib/asu/api.ts
+++ b/lib/asu/api.ts
@@ -113,9 +113,9 @@ function composeMeetingTimes(item: AsuApiClassItem): string {
 }
 
 function mapToClassDetails(item: AsuApiClassItem): ClassDetails {
-  const enrlCap = Number.parseInt(item.ENRLCAP ?? '0', 10);
-  const enrlTot = Number.parseInt(item.ENRLTOT ?? '0', 10);
-  const waitTot = Number.parseInt(item.WAITTOT ?? '0', 10);
+  const enrlCap = Number.parseInt(item.ENRLCAP || '0', 10);
+  const enrlTot = Number.parseInt(item.ENRLTOT || '0', 10);
+  const waitTot = Number.parseInt(item.WAITTOT || '0', 10);
 
   return {
     subject: item.SUBJECT,

--- a/tests/unit/lib/asu-api.test.ts
+++ b/tests/unit/lib/asu-api.test.ts
@@ -343,4 +343,53 @@ describe('fetchClassFromASU', () => {
       return error instanceof Error && error.message.includes('Section 99999 not found');
     });
   });
+
+  it('should handle empty string enrollment fields without returning NaN', async () => {
+    // Regression test for issue #169: Number.parseInt('', 10) returns NaN
+    // which causes Math.max(0, NaN) to return NaN, serializing as null in JSON
+    const responseWithEmptyStrings = {
+      hits: {
+        total: { value: 1 },
+        hits: [
+          {
+            _source: {
+              CLASSNBR: '12345',
+              SUBJECT: 'CSE',
+              CATALOGNBR: '101',
+              COURSETITLELONG: 'Introduction to Programming',
+              INSTRUCTORSLIST: ['Dr. Smith'],
+              ENRLCAP: '', // Empty string should be treated as 0
+              ENRLTOT: '', // Empty string should be treated as 0
+              WAITTOT: '', // Empty string should be treated as 0
+              FACILITYID: 'MAIN',
+              MON: 'Y',
+              TUES: 'N',
+              WED: 'Y',
+              THURS: 'N',
+              FRI: 'Y',
+              STARTTIME: '09:00:00',
+              ENDTIME: '10:15:00',
+            },
+          },
+        ],
+      },
+    };
+
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(responseWithEmptyStrings), { status: 200 })
+    );
+
+    const result = await fetchClassFromASU('12345', '2264', {
+      ASU_API_BASE_URL: 'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+      ASU_API_TOKEN: 'test-token',
+    });
+
+    // All seat counts should be valid numbers, not NaN
+    expect(result.seats_capacity).toBe(0);
+    expect(result.seats_available).toBe(0);
+    expect(result.non_reserved_seats).toBe(0);
+    expect(Number.isNaN(result.seats_capacity)).toBe(false);
+    expect(Number.isNaN(result.seats_available)).toBe(false);
+    expect(Number.isNaN(result.non_reserved_seats)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #169 - Number.parseInt produces NaN from non-numeric ASU fields when API returns empty strings.

## Problem

The ASU API can return empty strings for enrollment fields (ENRLCAP, ENRLTOT, WAITTOT). The original code used the nullish coalescing operator (??) which only catches null and undefined, not empty strings:

```typescript
const enrlCap = Number.parseInt(item.ENRLCAP ?? '0', 10);
```

When ENRLCAP is an empty string:
1. '' ?? '0' evaluates to '' (empty string is not null/undefined)
2. Number.parseInt('', 10) returns NaN
3. Math.max(0, NaN) returns NaN
4. NaN serializes as null in JSON responses

## Solution

Changed ?? to || (logical OR) which catches all falsy values including empty strings:

```typescript
const enrlCap = Number.parseInt(item.ENRLCAP || '0', 10);
```

## TDD Evidence

- **RED**: Wrote test with empty string fields → test failed with expected NaN to be +0
- **GREEN**: Changed ?? to || → test passes
- All 407 tests pass (1 new regression test added)

## Validation

- ✅ All tests pass (407/407)
- ✅ Lint clean (Biome checked 193 files)
- ✅ TypeScript type-check passes

## Files Changed

- lib/asu/api.ts: 3 lines changed (?? → ||)
- tests/unit/lib/asu-api.test.ts: Added regression test (49 lines)

Fixes #169
