### PR TITLE
fix(cron): use scheduled event time for stagger group computation

### DIFF
--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -94,7 +94,10 @@ export async function GET(request: NextRequest) {
     // Math.floor(currentMinute / 30) gives us: 0 for :00-:29, 1 for :30-:59
     // Modulo 2 alternates between 0 and 1 for each 30-minute window
     // Result: :00 → even (0 % 2 = 0), :30 → odd (1 % 2 = 1)
-    const now = new Date();
+    // Use scheduled time from header if available (from worker.ts cron handler)
+    // Falls back to current time for manual API calls or if header is missing
+    const scheduledTimeHeader = request.headers.get('X-Cron-Scheduled-Time');
+    const now = scheduledTimeHeader ? new Date(Number(scheduledTimeHeader)) : new Date();
     const currentMinute = now.getMinutes();
     const staggerGroup = Math.floor(currentMinute / 30) % 2 === 0 ? 'even' : 'odd';
 

--- a/tests/integration/api/cron.test.ts
+++ b/tests/integration/api/cron.test.ts
@@ -125,4 +125,34 @@ describe('GET /api/cron', () => {
     expect(responseData.batches_failed).toBe(1);
     expect(responseData.batches_total).toBe(2);
   });
+
+  it('uses X-Cron-Scheduled-Time header for stagger group computation', async () => {
+    // Arrange: Mock sections to check
+    const mockSections = Array.from({ length: 50 }, (_, i) => ({
+      class_nbr: String(10000 + i),
+      term: '2261',
+    }));
+    vi.mocked(getSectionsToCheck).mockResolvedValue(mockSections);
+
+    // Arrange: Mock queue to succeed
+    const { env } = await import('cloudflare:workers');
+    vi.mocked(env.PICKMYCLASS_QUEUE.sendBatch).mockResolvedValue(undefined);
+
+    // Set current time to :30 (odd stagger group)
+    vi.setSystemTime(new Date('2024-01-15T12:30:00Z'));
+
+    // Act: Send request with scheduled time header pointing to :00 (even stagger group)
+    const scheduledTime = new Date('2024-01-15T12:00:00Z').getTime();
+    const request = new NextRequest('http://localhost:3000/api/cron', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer test-cron-secret',
+        'X-Cron-Scheduled-Time': String(scheduledTime),
+      },
+    });
+    await GET(request);
+
+    // Assert: Should use 'even' stagger group based on header, not 'odd' from current time
+    expect(getSectionsToCheck).toHaveBeenCalledWith('even');
+  });
 });

--- a/worker.ts
+++ b/worker.ts
@@ -345,11 +345,14 @@ export default {
     try {
       // Make internal HTTP request to the API route
       // This allows us to reuse the same logic whether triggered by cron or manually
+      // Pass scheduled time as header so API route computes correct stagger group
+      // even if cron execution is delayed
       const request = new Request(`http://localhost${cronRoute}`, {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${env.CRON_SECRET}`,
           'User-Agent': 'Cloudflare-Workers-Cron',
+          'X-Cron-Scheduled-Time': String(event.scheduledTime),
         },
       });
 


### PR DESCRIPTION
## Summary

Fixes #171 - Stagger group was computed from wall clock instead of scheduled event time. When cron execution is delayed >30 minutes, this could cause wrong sections to be checked.

## Changes

- **worker.ts**: Pass  as  header when making internal cron requests
- **app/api/cron/route.ts**: Read  header to compute stagger group, with fallback to current time for manual API calls
- **tests**: Add test verifying header-based stagger group computation

## Validation

- TDD cycle completed: RED test (verified fails), GREEN implementation (verified passes)
- All 414 tests pass (1 new test added)
- Linting passes
- Type checking passes

## Testing

Test  verifies:
- When current time is :30 (odd group) but header specifies :00 (even group)
- API route correctly uses 'even' group from header instead of 'odd' from current time

Fixes #171