### PR TITLE
feat(queue): scope notification resets by term

### DIFF
--- a/app/api/queue/process-section/route.ts
+++ b/app/api/queue/process-section/route.ts
@@ -104,6 +104,7 @@ export async function POST(request: NextRequest) {
         changes_detected: {
           seat_became_available: result.changes.seatBecameAvailable,
           instructor_assigned: result.changes.instructorAssigned,
+          seats_filled: result.changes.seatsFilled,
         },
         emails_sent: result.emailsSent,
         processing_time_ms: result.processingTimeMs,

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -72,10 +72,12 @@ export async function getSectionsToCheck(
  * when seats open again.
  *
  * @param classNbr - Section number (e.g., "12431")
+ * @param term - Term code (e.g., "2261")
  * @param notificationType - Type of notification to reset (default: 'seat_available')
  */
 export async function resetNotificationsForSection(
   classNbr: string,
+  term: string,
   notificationType: 'seat_available' | 'instructor_assigned' = 'seat_available'
 ): Promise<void> {
   const supabase = getServiceClient();
@@ -83,7 +85,8 @@ export async function resetNotificationsForSection(
   const { data: watches, error: watchError } = await supabase
     .from('class_watches')
     .select('id')
-    .eq('class_nbr', classNbr);
+    .eq('class_nbr', classNbr)
+    .eq('term', term);
 
   if (watchError) {
     console.error(`[DB] Error fetching watches for reset:`, watchError);

--- a/lib/queue/process-section.ts
+++ b/lib/queue/process-section.ts
@@ -82,7 +82,7 @@ export async function processSection(
 
     // Step 4: Reset notifications if seats filled
     if (changes.seatsFilled) {
-      await resetNotificationsForSection(classNbr, 'seat_available');
+      await resetNotificationsForSection(classNbr, term, 'seat_available');
     }
 
     // Step 5: Send notifications if changes detected

--- a/tests/integration/api/process-section.test.ts
+++ b/tests/integration/api/process-section.test.ts
@@ -339,6 +339,64 @@ describe('POST /api/queue/process-section', () => {
       expect(data.changes_detected.instructor_assigned).toBe(false);
       expect(data.emails_sent).toBe(0);
     });
+
+    it('should reset notifications when seats are filled (seats 5 -> 0)', async () => {
+      // Mock existing state: 5 seats available
+      mockFrom.mockReturnValue({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  class_nbr: '12345',
+                  term: '2261',
+                  seats_available: 5,
+                  instructor_name: 'Staff',
+                },
+                error: null,
+              }),
+            })),
+          })),
+        })),
+        upsert: vi.fn().mockResolvedValue({ error: null }),
+      });
+
+      // Mock ASU API: 0 seats available
+      mockFetchClassFromASU.mockResolvedValue({
+        subject: 'CSE',
+        catalog_nbr: '110',
+        title: 'Intro to Programming',
+        instructor: 'Staff',
+        seats_available: 0,
+        seats_capacity: 30,
+        non_reserved_seats: null,
+        location: 'Online',
+        meeting_times: 'MWF 9:00-9:50',
+      });
+
+      const response = await POST(
+        createRequest(
+          JSON.stringify({ class_nbr: '12345', term: '2261' }),
+          'Bearer test-cron-secret'
+        )
+      );
+
+      const data = (await response.json()) as {
+        success: boolean;
+        changes_detected: {
+          seats_filled: boolean;
+        };
+      };
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.changes_detected.seats_filled).toBe(true);
+      expect(mockResetNotificationsForSection).toHaveBeenCalledWith(
+        '12345',
+        '2261',
+        'seat_available'
+      );
+    });
   });
 
   describe('rollback failure handling (issue #158)', () => {

--- a/tests/unit/lib/db/notification-expiration.test.ts
+++ b/tests/unit/lib/db/notification-expiration.test.ts
@@ -117,13 +117,21 @@ describe('Notification Expiration (Issue #157)', () => {
 
   describe('resetNotificationsForSection', () => {
     it('should reset seat_available notifications for a section', async () => {
-      mockFrom.mockReturnValue({
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+      };
+      mockQuery.eq.mockImplementation((key, _value) => {
+        if (key === 'term') {
+          return Promise.resolve({
             data: [{ id: 'watch-1' }, { id: 'watch-2' }],
             error: null,
-          })),
-        })),
+          });
+        }
+        return mockQuery;
+      });
+
+      mockFrom.mockReturnValue({
+        select: vi.fn(() => mockQuery),
         delete: vi.fn(() => ({
           in: vi.fn(() => ({
             eq: vi.fn().mockResolvedValue({ error: null }),
@@ -131,66 +139,74 @@ describe('Notification Expiration (Issue #157)', () => {
         })),
       });
 
-      // Need to handle the chained delete call differently
-      const mockDelete = vi.fn().mockResolvedValue({ error: null });
-      mockFrom.mockReturnValue({
-        select: vi.fn(() => ({
-          eq: vi.fn().mockResolvedValue({
-            data: [{ id: 'watch-1' }, { id: 'watch-2' }],
-            error: null,
-          }),
-        })),
-        delete: vi.fn(() => ({
-          in: vi.fn(() => ({
-            eq: mockDelete,
-          })),
-        })),
-      });
-
-      await resetNotificationsForSection('12345', 'seat_available');
+      await resetNotificationsForSection('12345', '2261', 'seat_available');
 
       expect(mockFrom).toHaveBeenCalledWith('class_watches');
     });
 
     it('should throw error when fetching watches fails', async () => {
-      mockFrom.mockReturnValue({
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+      };
+      mockQuery.eq.mockImplementation((key, _value) => {
+        if (key === 'term') {
+          return Promise.resolve({
             data: null,
             error: { message: 'Connection error' },
-          })),
-        })),
+          });
+        }
+        return mockQuery;
       });
 
-      await expect(resetNotificationsForSection('12345')).rejects.toThrow(
+      mockFrom.mockReturnValue({
+        select: vi.fn(() => mockQuery),
+      });
+
+      await expect(resetNotificationsForSection('12345', '2261')).rejects.toThrow(
         'Failed to fetch watches: Connection error'
       );
     });
 
     it('should do nothing when no watches found', async () => {
-      mockFrom.mockReturnValue({
-        select: vi.fn(() => ({
-          eq: vi.fn().mockResolvedValue({
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+      };
+      mockQuery.eq.mockImplementation((key, _value) => {
+        if (key === 'term') {
+          return Promise.resolve({
             data: [],
             error: null,
-          }),
-        })),
+          });
+        }
+        return mockQuery;
       });
 
-      await resetNotificationsForSection('12345', 'seat_available');
+      mockFrom.mockReturnValue({
+        select: vi.fn(() => mockQuery),
+      });
+
+      await resetNotificationsForSection('12345', '2261', 'seat_available');
 
       // Should not call delete when no watches found
       expect(mockFrom).toHaveBeenCalledTimes(1);
     });
 
     it('should handle instructor_assigned notification type', async () => {
-      mockFrom.mockReturnValue({
-        select: vi.fn(() => ({
-          eq: vi.fn().mockResolvedValue({
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+      };
+      mockQuery.eq.mockImplementation((key, _value) => {
+        if (key === 'term') {
+          return Promise.resolve({
             data: [{ id: 'watch-1' }],
             error: null,
-          }),
-        })),
+          });
+        }
+        return mockQuery;
+      });
+
+      mockFrom.mockReturnValue({
+        select: vi.fn(() => mockQuery),
         delete: vi.fn(() => ({
           in: vi.fn(() => ({
             eq: vi.fn().mockResolvedValue({ error: null }),
@@ -198,19 +214,27 @@ describe('Notification Expiration (Issue #157)', () => {
         })),
       });
 
-      await resetNotificationsForSection('12345', 'instructor_assigned');
+      await resetNotificationsForSection('12345', '2261', 'instructor_assigned');
 
       expect(mockFrom).toHaveBeenCalledWith('class_watches');
     });
 
     it('should use seat_available as default notification type', async () => {
-      mockFrom.mockReturnValue({
-        select: vi.fn(() => ({
-          eq: vi.fn().mockResolvedValue({
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+      };
+      mockQuery.eq.mockImplementation((key, _value) => {
+        if (key === 'term') {
+          return Promise.resolve({
             data: [{ id: 'watch-1' }],
             error: null,
-          }),
-        })),
+          });
+        }
+        return mockQuery;
+      });
+
+      mockFrom.mockReturnValue({
+        select: vi.fn(() => mockQuery),
         delete: vi.fn(() => ({
           in: vi.fn(() => ({
             eq: vi.fn().mockResolvedValue({ error: null }),
@@ -218,10 +242,39 @@ describe('Notification Expiration (Issue #157)', () => {
         })),
       });
 
-      await resetNotificationsForSection('12345');
+      await resetNotificationsForSection('12345', '2261');
 
       // Should default to seat_available
       expect(mockFrom).toHaveBeenCalledWith('class_watches');
+    });
+
+    it('should filter by both class_nbr and term', async () => {
+      const mockQuery = {
+        eq: vi.fn().mockReturnThis(),
+      };
+      mockQuery.eq.mockImplementation((key, _value) => {
+        if (key === 'term') {
+          return Promise.resolve({
+            data: [{ id: 'watch-1' }],
+            error: null,
+          });
+        }
+        return mockQuery;
+      });
+
+      mockFrom.mockReturnValue({
+        select: vi.fn(() => mockQuery),
+        delete: vi.fn(() => ({
+          in: vi.fn(() => ({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          })),
+        })),
+      });
+
+      await resetNotificationsForSection('12345', '2261');
+
+      expect(mockQuery.eq).toHaveBeenCalledWith('class_nbr', '12345');
+      expect(mockQuery.eq).toHaveBeenCalledWith('term', '2261');
     });
   });
 

--- a/tests/unit/lib/queue/process-section.test.ts
+++ b/tests/unit/lib/queue/process-section.test.ts
@@ -210,7 +210,7 @@ describe('processSection', () => {
 
     const result = await processSection('42737', '2261', buildEnv());
 
-    expect(resetNotificationsForSection).toHaveBeenCalledWith('42737', 'seat_available');
+    expect(resetNotificationsForSection).toHaveBeenCalledWith('42737', '2261', 'seat_available');
     expect(sendSectionNotifications).not.toHaveBeenCalled();
     expect(result.success).toBe(true);
   });


### PR DESCRIPTION
## Summary

This PR updates the notification reset logic to include `term` scoping. This ensures that when seats are filled for a specific class section, only notifications for that specific term are reset, preventing accidental resets for the same class number in other terms.

## Changes

- Updated `resetNotificationsForSection` in `lib/db/queries.ts` to accept `term` and filter `class_watches` by it.
- Updated `processSection` in `lib/queue/process-section.ts` to pass the `term` to the reset function.
- Included `seats_filled` in the API response in `app/api/queue/process-section/route.ts`.
- Updated unit and integration tests to verify the new scoping logic.

## Test Plan

- [x] Unit tests for notification expiration: `tests/unit/lib/db/notification-expiration.test.ts`
- [x] Unit tests for process-section: `tests/unit/lib/queue/process-section.test.ts`
- [x] Integration tests for API: `tests/integration/api/process-section.test.ts`

## Related Issues

Fixes the issue where notification resets were over-scoped to class number only.