### PR TITLE
feat(admin): add recent activity feed to admin dashboard

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,10 +1,12 @@
 export const dynamic = 'force-dynamic';
 
-import { Activity, Clock, Eye, Mail, TrendingUp, Users } from 'lucide-react';
+import { Activity, Eye, Mail, TrendingUp, Users } from 'lucide-react';
+import { RecentActivity } from '@/components/admin/RecentActivity';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { verifyAdmin } from '@/lib/auth/admin';
 import {
   getAdminCount,
+  getRecentActivity,
   getTotalClassesWatched,
   getTotalEmailsSent,
   getTotalUsers,
@@ -20,18 +22,19 @@ import {
  * - Total emails sent (notifications)
  * - Total registered users
  * - Total unique classes being watched
- * - Recent activity section (placeholder for future expansion)
+ * - Recent activity feed (registrations, watches, emails)
  */
 export default async function AdminDashboardPage() {
   // Verify admin access - redirects if not authenticated or not admin
   const adminUser = await verifyAdmin();
 
   // Fetch all statistics in parallel
-  const [totalEmails, totalUsers, totalClasses, adminCount] = await Promise.all([
+  const [totalEmails, totalUsers, totalClasses, adminCount, recentActivity] = await Promise.all([
     getTotalEmailsSent(),
     getTotalUsers(),
     getTotalClassesWatched(),
     getAdminCount(),
+    getRecentActivity(10),
   ]);
 
   // Calculate engagement metrics
@@ -152,36 +155,9 @@ export default async function AdminDashboardPage() {
         </div>
       </div>
 
-      {/* Recent Activity Section - Placeholder */}
+      {/* Recent Activity Section */}
       <div className="mb-8">
-        <h2 className="text-xl font-semibold mb-4">Recent Activity</h2>
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-3">
-              <div className="flex size-10 items-center justify-center rounded-full bg-muted">
-                <Clock className="size-5 text-muted-foreground" />
-              </div>
-              <div>
-                <CardTitle className="text-base">Activity Feed Coming Soon</CardTitle>
-                <p className="text-sm text-muted-foreground mt-1">
-                  Real-time monitoring and activity logs will be displayed here
-                </p>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="text-sm text-muted-foreground space-y-2">
-              <p>Future features:</p>
-              <ul className="list-disc list-inside space-y-1 ml-2">
-                <li>Recent user registrations</li>
-                <li>Latest email notifications sent</li>
-                <li>New class watches added</li>
-                <li>System health metrics</li>
-                <li>ASU API status</li>
-              </ul>
-            </div>
-          </CardContent>
-        </Card>
+        <RecentActivity items={recentActivity} />
       </div>
 
       {/* System Info Footer */}

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/components/admin/RecentActivity.tsx
+++ b/components/admin/RecentActivity.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { Eye, Mail, Users } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { RecentActivityItem } from '@/lib/db/admin-queries';
+
+interface RecentActivityProps {
+  items: RecentActivityItem[];
+}
+
+const iconByType = {
+  user_registration: Users,
+  new_watch: Eye,
+  email_sent: Mail,
+} as const;
+
+function formatNotificationType(notificationType: RecentActivityItem['notificationType']): string {
+  if (!notificationType) return '';
+  return notificationType === 'seat_available' ? 'seat available' : 'instructor assigned';
+}
+
+export function RecentActivity({ items }: RecentActivityProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Recent Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No recent activity to display</p>
+        ) : (
+          <ul className="space-y-3">
+            {items.map((item, index) => {
+              const Icon = iconByType[item.type];
+              return (
+                <li key={index} className="flex items-start gap-3">
+                  <div className="flex size-8 items-center justify-center rounded-full bg-muted shrink-0 mt-0.5">
+                    <Icon className="size-4 text-muted-foreground" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm">
+                      <span className="font-medium">{item.userEmail}</span>
+                      {item.type === 'user_registration' && ' registered'}
+                      {item.type === 'new_watch' && item.subject && item.catalogNbr && (
+                        <>
+                          {' '}
+                          started watching{' '}
+                          <span className="font-medium">
+                            {item.subject} {item.catalogNbr}
+                          </span>
+                          {item.classNbr && ` (section ${item.classNbr})`}
+                        </>
+                      )}
+                      {item.type === 'email_sent' && item.notificationType && (
+                        <>
+                          {' '}
+                          notified about{' '}
+                          <span className="font-medium">
+                            {formatNotificationType(item.notificationType)}
+                          </span>
+                          {item.classNbr && ` for section ${item.classNbr}`}
+                        </>
+                      )}
+                    </p>
+                    <time
+                      className="text-xs text-muted-foreground block mt-0.5"
+                      dateTime={item.activityAt}
+                      title={new Date(item.activityAt).toUTCString()}
+                    >
+                      {new Date(item.activityAt).toLocaleString()}
+                    </time>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/RecentActivity.tsx
+++ b/components/admin/RecentActivity.tsx
@@ -30,10 +30,13 @@ export function RecentActivity({ items }: RecentActivityProps) {
           <p className="text-sm text-muted-foreground">No recent activity to display</p>
         ) : (
           <ul className="space-y-3">
-            {items.map((item, index) => {
+            {items.map((item) => {
               const Icon = iconByType[item.type];
               return (
-                <li key={index} className="flex items-start gap-3">
+                <li
+                  key={`${item.type}-${item.userEmail}-${item.activityAt}`}
+                  className="flex items-start gap-3"
+                >
                   <div className="flex size-8 items-center justify-center rounded-full bg-muted shrink-0 mt-0.5">
                     <Icon className="size-4 text-muted-foreground" />
                   </div>

--- a/lib/db/admin-queries.ts
+++ b/lib/db/admin-queries.ts
@@ -480,6 +480,79 @@ export async function getAllUsersWithWatchCount(): Promise<UserWithWatchCount[]>
 }
 
 /**
+ * A single recent activity item returned from the unified feed.
+ */
+
+export type ActivityType = 'user_registration' | 'new_watch' | 'email_sent';
+
+export interface RecentActivityItem {
+  type: ActivityType;
+  activityAt: string;
+  userEmail: string;
+  classNbr: string | null;
+  subject: string | null;
+  catalogNbr: string | null;
+  notificationType: 'seat_available' | 'instructor_assigned' | null;
+}
+
+/**
+ * Get the most recent platform activity.
+ *
+ * Calls the `get_recent_activity` RPC which unions:
+ * - `auth.users` (registrations)
+ * - `class_watches` (new watches)
+ * - `notifications_sent` (email notifications)
+ *
+ * Results are cached for 5 minutes.
+ *
+ * @param limit - Maximum number of items to return (default: 50)
+ * @returns Array of unified activity items ordered by `activityAt` descending
+ */
+/**
+ * Raw row returned by the get_recent_activity RPC.
+ */
+interface RecentActivityRow {
+  activity_type: string;
+  activity_at: string;
+  user_email: string;
+  class_nbr: string | null;
+  subject: string | null;
+  catalog_nbr: string | null;
+  notification_type: string | null;
+}
+
+export async function getRecentActivity(limit: number = 50): Promise<RecentActivityItem[]> {
+  const cacheKey = `recent-activity-${limit}`;
+  const cached = adminCache.get(cacheKey) as RecentActivityItem[] | undefined;
+  if (cached !== undefined) return cached;
+
+  const supabase = getServiceClient();
+
+  const { data, error } = (await supabase.rpc(
+    'get_recent_activity' as 'get_class_watchers',
+    { p_limit: limit } as unknown as { section_number: string }
+  )) as unknown as { data: RecentActivityRow[] | null; error: Error | null };
+
+  if (error) {
+    console.error('[Admin] Error fetching recent activity:', error);
+    throw new Error(`Failed to fetch recent activity: ${error.message}`);
+  }
+
+  const items: RecentActivityItem[] = (data || []).map((row) => ({
+    type: row.activity_type as ActivityType,
+    activityAt: row.activity_at,
+    userEmail: row.user_email,
+    classNbr: row.class_nbr,
+    subject: row.subject,
+    catalogNbr: row.catalog_nbr,
+    notificationType: row.notification_type as 'seat_available' | 'instructor_assigned' | null,
+  }));
+
+  adminCache.set(cacheKey, items);
+  return items;
+}
+
+/**
  * Get all class watches for a specific user
  *
  * Retrieves all watches for a given user ID and joins with class_states

--- a/lib/db/admin-queries.ts
+++ b/lib/db/admin-queries.ts
@@ -522,7 +522,12 @@ interface RecentActivityRow {
 }
 
 export async function getRecentActivity(limit: number = 50): Promise<RecentActivityItem[]> {
-  const cacheKey = `recent-activity-${limit}`;
+  if (!Number.isFinite(limit) || limit <= 0) {
+    throw new TypeError('Invalid limit: must be a finite positive integer');
+  }
+  const sanitizedLimit = Math.min(Math.floor(limit), 500);
+
+  const cacheKey = `recent-activity-${sanitizedLimit}`;
   const cached = adminCache.get(cacheKey) as RecentActivityItem[] | undefined;
   if (cached !== undefined) return cached;
 
@@ -530,7 +535,7 @@ export async function getRecentActivity(limit: number = 50): Promise<RecentActiv
 
   const { data, error } = (await supabase.rpc(
     'get_recent_activity' as 'get_class_watchers',
-    { p_limit: limit } as unknown as { section_number: string }
+    { p_limit: sanitizedLimit } as unknown as { section_number: string }
   )) as unknown as { data: RecentActivityRow[] | null; error: Error | null };
 
   if (error) {

--- a/lib/db/admin-queries.ts
+++ b/lib/db/admin-queries.ts
@@ -525,7 +525,7 @@ export async function getRecentActivity(limit: number = 50): Promise<RecentActiv
   if (!Number.isFinite(limit) || limit <= 0) {
     throw new TypeError('Invalid limit: must be a finite positive integer');
   }
-  const sanitizedLimit = Math.min(Math.floor(limit), 500);
+  const sanitizedLimit = Math.min(500, Math.max(1, Math.floor(limit)));
 
   const cacheKey = `recent-activity-${sanitizedLimit}`;
   const cached = adminCache.get(cacheKey) as RecentActivityItem[] | undefined;

--- a/supabase/migrations/20260519000000_add_recent_activity_function.sql
+++ b/supabase/migrations/20260519000000_add_recent_activity_function.sql
@@ -69,5 +69,9 @@ BEGIN
 END;
 $$;
 
+REVOKE EXECUTE ON FUNCTION public.get_recent_activity(INTEGER) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_recent_activity(INTEGER) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_recent_activity(INTEGER) TO service_role;
+
 COMMENT ON FUNCTION public.get_recent_activity(INTEGER) IS
   'Returns a unified recent activity feed combining user registrations, new class watches, and sent email notifications. Used by the admin dashboard. SECURITY DEFINER is required to access auth.users.';

--- a/supabase/migrations/20260519000000_add_recent_activity_function.sql
+++ b/supabase/migrations/20260519000000_add_recent_activity_function.sql
@@ -1,0 +1,73 @@
+-- Add covering indexes for recent activity queries
+CREATE INDEX IF NOT EXISTS idx_notifications_sent_sent_at
+  ON public.notifications_sent(sent_at DESC, class_watch_id, notification_type);
+
+CREATE INDEX IF NOT EXISTS idx_class_watches_created_at
+  ON public.class_watches(created_at DESC, user_id, class_nbr, subject, catalog_nbr);
+
+-- Unified recent activity feed
+-- Unions auth.users (registrations), class_watches (new watches), and notifications_sent (emails)
+CREATE OR REPLACE FUNCTION public.get_recent_activity(p_limit INTEGER DEFAULT 50)
+RETURNS TABLE (
+  activity_type TEXT,
+  activity_at TIMESTAMP WITH TIME ZONE,
+  user_email TEXT,
+  class_nbr TEXT,
+  subject TEXT,
+  catalog_nbr TEXT,
+  notification_type TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  (
+    SELECT
+      'user_registration'::TEXT as activity_type,
+      u.created_at as activity_at,
+      u.email::TEXT as user_email,
+      NULL::TEXT as class_nbr,
+      NULL::TEXT as subject,
+      NULL::TEXT as catalog_nbr,
+      NULL::TEXT as notification_type
+    FROM auth.users u
+    ORDER BY u.created_at DESC
+  )
+  UNION ALL
+  (
+    SELECT
+      'new_watch'::TEXT as activity_type,
+      cw.created_at as activity_at,
+      auth_u.email::TEXT as user_email,
+      cw.class_nbr,
+      cw.subject,
+      cw.catalog_nbr,
+      NULL::TEXT as notification_type
+    FROM public.class_watches cw
+    INNER JOIN auth.users auth_u ON auth_u.id = cw.user_id
+    ORDER BY cw.created_at DESC
+  )
+  UNION ALL
+  (
+    SELECT
+      'email_sent'::TEXT as activity_type,
+      ns.sent_at as activity_at,
+      auth_u.email::TEXT as user_email,
+      cw.class_nbr,
+      cw.subject,
+      cw.catalog_nbr,
+      ns.notification_type::TEXT
+    FROM public.notifications_sent ns
+    INNER JOIN public.class_watches cw ON cw.id = ns.class_watch_id
+    INNER JOIN auth.users auth_u ON auth_u.id = cw.user_id
+    ORDER BY ns.sent_at DESC
+  )
+  ORDER BY activity_at DESC
+  LIMIT p_limit;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_recent_activity(INTEGER) IS
+  'Returns a unified recent activity feed combining user registrations, new class watches, and sent email notifications. Used by the admin dashboard. SECURITY DEFINER is required to access auth.users.';

--- a/supabase/migrations/20260519000000_add_recent_activity_function.sql
+++ b/supabase/migrations/20260519000000_add_recent_activity_function.sql
@@ -71,6 +71,7 @@ $$;
 
 REVOKE EXECUTE ON FUNCTION public.get_recent_activity(INTEGER) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION public.get_recent_activity(INTEGER) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_recent_activity(INTEGER) FROM anon;
 GRANT EXECUTE ON FUNCTION public.get_recent_activity(INTEGER) TO service_role;
 
 COMMENT ON FUNCTION public.get_recent_activity(INTEGER) IS

--- a/tests/unit/components/admin/RecentActivity.test.tsx
+++ b/tests/unit/components/admin/RecentActivity.test.tsx
@@ -59,7 +59,7 @@ describe('RecentActivity', () => {
     expect(times).toHaveLength(4);
 
     expect(times[0]).toHaveAttribute('dateTime', '2026-05-19T10:00:00Z');
-    expect(times[0]).toHaveAttribute('title', expect.stringContaining('UTC'));
+    expect(times[0]).toHaveAttribute('title', expect.stringMatching(/GMT|UTC/));
   });
 
   it('renders empty state when no items provided', () => {

--- a/tests/unit/components/admin/RecentActivity.test.tsx
+++ b/tests/unit/components/admin/RecentActivity.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RecentActivity } from '@/components/admin/RecentActivity';
+import type { RecentActivityItem } from '@/lib/db/admin-queries';
+
+const mockItems: RecentActivityItem[] = [
+  {
+    type: 'user_registration',
+    activityAt: '2026-05-19T10:00:00Z',
+    userEmail: 'alice@example.com',
+    classNbr: null,
+    subject: null,
+    catalogNbr: null,
+    notificationType: null,
+  },
+  {
+    type: 'new_watch',
+    activityAt: '2026-05-19T09:30:00Z',
+    userEmail: 'bob@example.com',
+    classNbr: '12431',
+    subject: 'CSE',
+    catalogNbr: '240',
+    notificationType: null,
+  },
+  {
+    type: 'email_sent',
+    activityAt: '2026-05-19T09:00:00Z',
+    userEmail: 'charlie@example.com',
+    classNbr: '12431',
+    subject: 'CSE',
+    catalogNbr: '240',
+    notificationType: 'seat_available',
+  },
+  {
+    type: 'email_sent',
+    activityAt: '2026-05-19T08:00:00Z',
+    userEmail: 'diana@example.com',
+    classNbr: '12431',
+    subject: 'CSE',
+    catalogNbr: '240',
+    notificationType: 'instructor_assigned',
+  },
+];
+
+describe('RecentActivity', () => {
+  it('renders all activity items with correct descriptions', () => {
+    render(<RecentActivity items={mockItems} />);
+
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument();
+    expect(screen.getByText('charlie@example.com')).toBeInTheDocument();
+    expect(screen.getByText('diana@example.com')).toBeInTheDocument();
+  });
+
+  it('renders ISO time elements with UTC tooltip for each item', () => {
+    render(<RecentActivity items={mockItems} />);
+
+    const times = screen.getAllByRole('time');
+    expect(times).toHaveLength(4);
+
+    expect(times[0]).toHaveAttribute('dateTime', '2026-05-19T10:00:00Z');
+    expect(times[0]).toHaveAttribute('title', expect.stringContaining('UTC'));
+  });
+
+  it('renders empty state when no items provided', () => {
+    render(<RecentActivity items={[]} />);
+
+    expect(screen.getByText(/no recent activity/i)).toBeInTheDocument();
+  });
+
+  it('renders class and subject info for watch items', () => {
+    render(<RecentActivity items={mockItems} />);
+
+    expect(screen.getByText(/CSE 240/i)).toBeInTheDocument();
+    // Match the watch-specific section format: "(section 12431)" not email's "for section 12431"
+    expect(screen.getByText(/\(section 12431\)/)).toBeInTheDocument();
+  });
+
+  it('renders notification type labels for email items', () => {
+    render(<RecentActivity items={mockItems} />);
+
+    expect(screen.getByText(/seat available/i)).toBeInTheDocument();
+    expect(screen.getByText(/instructor assigned/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/lib/db/admin-queries.test.ts
+++ b/tests/unit/lib/db/admin-queries.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRpc = vi.fn();
+
+vi.mock('@/lib/supabase/service', () => ({
+  getServiceClient: vi.fn(() => ({
+    rpc: (name: string, params: unknown) => mockRpc(name, params),
+  })),
+}));
+
+// Import after mocks are registered
+import { getRecentActivity } from '@/lib/db/admin-queries';
+
+describe('getRecentActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return discriminated union items for all activity types', async () => {
+    const mockData = [
+      {
+        activity_type: 'user_registration',
+        activity_at: '2026-05-19T10:00:00Z',
+        user_email: 'alice@example.com',
+        class_nbr: null,
+        subject: null,
+        catalog_nbr: null,
+        notification_type: null,
+      },
+      {
+        activity_type: 'new_watch',
+        activity_at: '2026-05-19T09:30:00Z',
+        user_email: 'bob@example.com',
+        class_nbr: '12431',
+        subject: 'CSE',
+        catalog_nbr: '240',
+        notification_type: null,
+      },
+      {
+        activity_type: 'email_sent',
+        activity_at: '2026-05-19T09:00:00Z',
+        user_email: 'charlie@example.com',
+        class_nbr: '12431',
+        subject: 'CSE',
+        catalog_nbr: '240',
+        notification_type: 'seat_available',
+      },
+    ];
+    mockRpc.mockResolvedValue({ data: mockData, error: null });
+
+    const result = await getRecentActivity(10);
+
+    expect(mockRpc).toHaveBeenCalledWith('get_recent_activity', {
+      p_limit: 10,
+    });
+
+    expect(result).toHaveLength(3);
+
+    expect(result[0]).toEqual({
+      type: 'user_registration',
+      activityAt: '2026-05-19T10:00:00Z',
+      userEmail: 'alice@example.com',
+      classNbr: null,
+      subject: null,
+      catalogNbr: null,
+      notificationType: null,
+    });
+
+    expect(result[1]).toEqual({
+      type: 'new_watch',
+      activityAt: '2026-05-19T09:30:00Z',
+      userEmail: 'bob@example.com',
+      classNbr: '12431',
+      subject: 'CSE',
+      catalogNbr: '240',
+      notificationType: null,
+    });
+
+    expect(result[2]).toEqual({
+      type: 'email_sent',
+      activityAt: '2026-05-19T09:00:00Z',
+      userEmail: 'charlie@example.com',
+      classNbr: '12431',
+      subject: 'CSE',
+      catalogNbr: '240',
+      notificationType: 'seat_available',
+    });
+  });
+
+  it('should use default limit of 50 when none provided', async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    await getRecentActivity();
+
+    expect(mockRpc).toHaveBeenCalledWith('get_recent_activity', {
+      p_limit: 50,
+    });
+  });
+
+  it('should return empty array when no activity exists', async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    const result = await getRecentActivity(15);
+
+    expect(mockRpc).toHaveBeenCalledWith('get_recent_activity', {
+      p_limit: 15,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('should throw error when RPC fails', async () => {
+    mockRpc.mockResolvedValue({
+      data: null,
+      error: { message: 'Database connection failed' },
+    });
+
+    await expect(getRecentActivity(20)).rejects.toThrow(
+      'Failed to fetch recent activity: Database connection failed'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a real-time recent activity feed to the admin dashboard, replacing the previous placeholder section. The feed shows user registrations, new class watches, and sent email notifications with timestamps and contextual icons.

## Changes

- Replace placeholder activity section with live RecentActivity React component
- Add getRecentActivity query layer using unified get_recent_activity Supabase RPC
- Add RecentActivity component with lucide-react icons and accessible time elements
- Add Supabase SQL migration for get_recent_activity function
- Add unit tests for RecentActivity component and admin-queries query layer
- Fix CodeRabbit review: remove redundant " UTC" suffix in time tooltip title
- Update Biome schema version to 2.4.15 (via pre-commit hook)

## Test Plan

- [x] Unit tests pass (bun run test:run)
- [x] Type check passes (bun run type-check)
- [x] Biome lint/format passes (bun run lint && bun run format)
- [x] CodeRabbit review feedback addressed

## Related Issues

N/A
