### PR TITLE
fix(components): update term dropdown for 2026

### DIFF
--- a/components/AddClassWatch.tsx
+++ b/components/AddClassWatch.tsx
@@ -93,8 +93,8 @@ export function AddClassWatch({ onAdd }: AddClassWatchProps) {
                 <SelectValue placeholder="Select term" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="2261">Spring 2026 (2261)</SelectItem>
                 <SelectItem value="2264">Summer 2026 (2264)</SelectItem>
+                <SelectItem value="2267">Fall 2026 (2267)</SelectItem>
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">Select the term to monitor</p>

--- a/tests/unit/components/interaction-components.test.tsx
+++ b/tests/unit/components/interaction-components.test.tsx
@@ -91,8 +91,8 @@ vi.mock('@/components/ui/select', () => ({
     >
       <option value="">Select term</option>
       <option value="asu">Arizona State University (ASU)</option>
-      <option value="2261">Spring 2026 (2261)</option>
       <option value="2264">Summer 2026 (2264)</option>
+      <option value="2267">Fall 2026 (2267)</option>
     </select>
   ),
   SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -164,7 +164,7 @@ describe('interactive components', () => {
     ).toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('combobox', { name: /term/i }), {
-      target: { value: '2261' },
+      target: { value: '2264' },
     });
     fireEvent.change(screen.getByLabelText(/section number/i), { target: { value: '123' } });
     fireEvent.submit(screen.getByRole('button', { name: /start watching/i }).closest('form')!);
@@ -172,7 +172,7 @@ describe('interactive components', () => {
 
     fireEvent.change(screen.getByLabelText(/section number/i), { target: { value: '12345' } });
     fireEvent.submit(screen.getByRole('button', { name: /start watching/i }).closest('form')!);
-    await waitFor(() => expect(onAdd).toHaveBeenCalledWith({ term: '2261', class_nbr: '12345' }));
+    await waitFor(() => expect(onAdd).toHaveBeenCalledWith({ term: '2264', class_nbr: '12345' }));
   });
 
   it('shows add-class submission errors', async () => {
@@ -180,7 +180,7 @@ describe('interactive components', () => {
     render(<AddClassWatch onAdd={onAdd} />);
 
     fireEvent.change(screen.getByRole('combobox', { name: /term/i }), {
-      target: { value: '2261' },
+      target: { value: '2264' },
     });
     fireEvent.change(screen.getByLabelText(/section number/i), { target: { value: '12345' } });
     fireEvent.submit(screen.getByRole('button', { name: /start watching/i }).closest('form')!);


### PR DESCRIPTION
## Summary
Updates the Add Class Watch term dropdown to reflect current ASU registration terms.

## Changes
- Removes expired Spring 2026 (2261)
- Adds Fall 2026 (2267)
- Keeps Summer 2026 (2264)

## Testing
- All 7 interaction component tests pass
