### PR TITLE
fix(components): automate ASU term picker with calendar-driven logic

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,7 +4,7 @@ This document defines domain terms used throughout the codebase. New modules sho
 
 ## Core Concepts
 
-- **Class Section** — An ASU course section, identified by `class_nbr` (5-digit) + `term` (4-digit YYSM code, e.g. "2261" for Spring 2026). Each section is a single offering of a course with a specific instructor, schedule, and seat capacity. The class picker shows only the current and next selectable terms, driven by the ASU academic calendar in [`lib/asu/terms.ts`](../lib/asu/terms.ts). Extend that calendar each August when ASU publishes the next academic year.
+- **Class Section** — An ASU course section, identified by `class_nbr` (5-digit) + `term` (4-digit YYSM code, e.g. "2261" for Spring 2026). Each section is a single offering of a course with a specific instructor, schedule, and seat capacity. The class picker shows only the current and next selectable terms, driven by the ASU academic calendar in [`lib/asu/terms.ts`](./lib/asu/terms.ts). Extend that calendar each August when ASU publishes the next academic year.
 
 - **Class Watch** — A user's subscription to monitor a Class Section for changes. Each watch belongs to one user and targets one section. Users are limited to `MAX_WATCHES_PER_USER` (default: 10).
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,7 +4,7 @@ This document defines domain terms used throughout the codebase. New modules sho
 
 ## Core Concepts
 
-- **Class Section** — An ASU course section, identified by `class_nbr` (5-digit) + `term` (4-digit YYSM code, e.g. "2261" for Spring 2026). Each section is a single offering of a course with a specific instructor, schedule, and seat capacity.
+- **Class Section** — An ASU course section, identified by `class_nbr` (5-digit) + `term` (4-digit YYSM code, e.g. "2261" for Spring 2026). Each section is a single offering of a course with a specific instructor, schedule, and seat capacity. The class picker shows only the current and next selectable terms, driven by the ASU academic calendar in [`lib/asu/terms.ts`](../lib/asu/terms.ts). Extend that calendar each August when ASU publishes the next academic year.
 
 - **Class Watch** — A user's subscription to monitor a Class Section for changes. Each watch belongs to one user and targets one section. Users are limited to `MAX_WATCHES_PER_USER` (default: 10).
 

--- a/app/api/queue/process-section/route.ts
+++ b/app/api/queue/process-section/route.ts
@@ -7,14 +7,11 @@
 
 import { env } from 'cloudflare:workers';
 import { type NextRequest, NextResponse } from 'next/server';
-import { createClassWatchSchema } from '@/lib/api/schemas';
+import { classCheckMessageSchema } from '@/lib/api/schemas';
 import { ApiError, AuthError, NotFoundError, RateLimitError } from '@/lib/asu/api';
 import { processSection } from '@/lib/queue/process-section';
 import type { Env } from '@/lib/types/env';
 import { timingSafeCompare } from '@/lib/utils/crypto';
-
-// Reuse the class watch schema for queue message validation (same fields)
-const classCheckMessageSchema = createClassWatchSchema;
 
 /**
  * Process a single class section message from the queue

--- a/components/AddClassWatch.tsx
+++ b/components/AddClassWatch.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Lock } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { formatTermOption, getSelectableTerms } from '@/lib/asu/terms';
 import { Alert } from './ui/alert';
 import { Button } from './ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
@@ -14,11 +15,14 @@ interface AddClassWatchProps {
 }
 
 export function AddClassWatch({ onAdd }: AddClassWatchProps) {
+  const selectableTerms = useMemo(() => getSelectableTerms(), []);
+  const defaultTerm = selectableTerms[0]?.code ?? '';
+
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [university] = useState('asu');
-  const [term, setTerm] = useState('');
+  const [term, setTerm] = useState(defaultTerm);
   const [classNbr, setClassNbr] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -43,7 +47,7 @@ export function AddClassWatch({ onAdd }: AddClassWatchProps) {
         class_nbr: classNbr,
       });
       // Reset form on success
-      setTerm('');
+      setTerm(defaultTerm);
       setClassNbr('');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add class watch');
@@ -88,15 +92,24 @@ export function AddClassWatch({ onAdd }: AddClassWatchProps) {
           {/* Term Dropdown */}
           <div className="space-y-2">
             <Label htmlFor="term">Term *</Label>
-            <Select value={term} onValueChange={setTerm} required>
-              <SelectTrigger id="term">
-                <SelectValue placeholder="Select term" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="2264">Summer 2026 (2264)</SelectItem>
-                <SelectItem value="2267">Fall 2026 (2267)</SelectItem>
-              </SelectContent>
-            </Select>
+            {selectableTerms.length === 0 ? (
+              <Alert className="bg-destructive/10 text-destructive border-destructive/30">
+                No terms are currently available. Please check back later or contact support.
+              </Alert>
+            ) : (
+              <Select value={term} onValueChange={setTerm} required>
+                <SelectTrigger id="term">
+                  <SelectValue placeholder="Select term" />
+                </SelectTrigger>
+                <SelectContent>
+                  {selectableTerms.map((termOption) => (
+                    <SelectItem key={termOption.code} value={termOption.code}>
+                      {formatTermOption(termOption)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
             <p className="text-xs text-muted-foreground">Select the term to monitor</p>
           </div>
 
@@ -134,7 +147,7 @@ export function AddClassWatch({ onAdd }: AddClassWatchProps) {
           <Button
             type="submit"
             variant="gradient"
-            disabled={isSubmitting || !term || !classNbr}
+            disabled={isSubmitting || !term || !classNbr || selectableTerms.length === 0}
             className="w-full"
           >
             {isSubmitting ? "Checking ASU's class search... hang tight" : 'Start Watching'}

--- a/lib/api/schemas.ts
+++ b/lib/api/schemas.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+import { isTermSelectable } from '@/lib/asu/terms';
 
 /**
  * Term code validation (4-digit format: YYSM)
@@ -41,15 +42,34 @@ export const registerPasswordSchema = z.string().min(8, 'Password must be at lea
  */
 export const uuidSchema = z.string().uuid('ID must be a valid UUID');
 
+const selectableTermRefinement = {
+  message: 'This term is no longer available. Please refresh and select a current term.',
+  path: ['term'],
+};
+
+function isSelectableTermCode(term: string): boolean {
+  return isTermSelectable(term);
+}
+
 // --- Pre-built schemas for common route inputs ---
+
+const classWatchFieldsSchema = z.object({
+  term: termSchema.min(1, 'Term is required'),
+  class_nbr: classNbrSchema.min(1, 'Class number is required'),
+});
+
+/**
+ * Schema for queue/cron messages — format only so existing watches on past terms keep processing.
+ */
+export const classCheckMessageSchema = classWatchFieldsSchema;
 
 /**
  * Schema for class watch creation (term + class_nbr)
  */
-export const createClassWatchSchema = z.object({
-  term: termSchema.min(1, 'Term is required'),
-  class_nbr: classNbrSchema.min(1, 'Class number is required'),
-});
+export const createClassWatchSchema = classWatchFieldsSchema.refine(
+  (data) => isSelectableTermCode(data.term),
+  selectableTermRefinement
+);
 
 /**
  * Schema for class watch deletion (watch ID)
@@ -61,10 +81,12 @@ export const deleteClassWatchSchema = z.object({
 /**
  * Schema for fetching class details
  */
-export const fetchClassDetailsSchema = z.object({
-  term: termSchema.min(1, 'Term is required'),
-  class_nbr: classNbrSchema.min(1, 'Section number is required'),
-});
+export const fetchClassDetailsSchema = z
+  .object({
+    term: termSchema.min(1, 'Term is required'),
+    class_nbr: classNbrSchema.min(1, 'Section number is required'),
+  })
+  .refine((data) => isSelectableTermCode(data.term), selectableTermRefinement);
 
 /**
  * Schema for login requests

--- a/lib/asu/terms.ts
+++ b/lib/asu/terms.ts
@@ -1,0 +1,265 @@
+/**
+ * ASU academic term calendar and selection logic.
+ *
+ * Term codes follow 2YYS format (e.g. "2261" = Spring 2026, "2264" = Summer, "2267" = Fall).
+ * Extend ASU_TERM_CALENDAR each August when ASU publishes the next academic year:
+ * https://registrar.asu.edu/academic-calendar
+ */
+
+export type AsuSeason = 'spring' | 'summer' | 'fall';
+
+export interface DateParts {
+  year: number;
+  month: number;
+  day: number;
+}
+
+export interface AsuTerm {
+  code: string;
+  label: string;
+  season: AsuSeason;
+  year: number;
+  /** When ASU class search catalog lists this term */
+  catalogAvailable: DateParts;
+  /** Session C classes begin */
+  sessionStart: DateParts;
+  /** Session C finals end — term drops from picker after this date */
+  sessionEnd: DateParts;
+}
+
+const ASU_TIMEZONE = 'America/Phoenix';
+
+const SEASON_SUFFIX: Record<AsuSeason, number> = {
+  spring: 1,
+  summer: 4,
+  fall: 7,
+};
+
+const SEASON_LABEL: Record<AsuSeason, string> = {
+  spring: 'Spring',
+  summer: 'Summer',
+  fall: 'Fall',
+};
+
+/**
+ * ASU academic calendar dates sourced from registrar.asu.edu/academic-calendar.
+ * Dates use America/Phoenix (no DST).
+ */
+export const ASU_TERM_CALENDAR: AsuTerm[] = [
+  // 2025
+  term(
+    2025,
+    'spring',
+    { year: 2024, month: 9, day: 23 },
+    { year: 2025, month: 1, day: 13 },
+    { year: 2025, month: 5, day: 9 }
+  ),
+  term(
+    2025,
+    'summer',
+    { year: 2025, month: 2, day: 6 },
+    { year: 2025, month: 5, day: 19 },
+    { year: 2025, month: 8, day: 12 }
+  ),
+  term(
+    2025,
+    'fall',
+    { year: 2025, month: 2, day: 24 },
+    { year: 2025, month: 8, day: 21 },
+    { year: 2025, month: 12, day: 13 }
+  ),
+  // 2026
+  term(
+    2026,
+    'spring',
+    { year: 2025, month: 9, day: 22 },
+    { year: 2026, month: 1, day: 12 },
+    { year: 2026, month: 5, day: 9 }
+  ),
+  term(
+    2026,
+    'summer',
+    { year: 2026, month: 2, day: 5 },
+    { year: 2026, month: 5, day: 18 },
+    { year: 2026, month: 8, day: 14 }
+  ),
+  term(
+    2026,
+    'fall',
+    { year: 2026, month: 2, day: 23 },
+    { year: 2026, month: 8, day: 20 },
+    { year: 2026, month: 12, day: 12 }
+  ),
+  // 2027
+  term(
+    2027,
+    'spring',
+    { year: 2026, month: 9, day: 21 },
+    { year: 2027, month: 1, day: 11 },
+    { year: 2027, month: 5, day: 8 }
+  ),
+  term(
+    2027,
+    'summer',
+    { year: 2027, month: 2, day: 4 },
+    { year: 2027, month: 5, day: 17 },
+    { year: 2027, month: 8, day: 13 }
+  ),
+  term(
+    2027,
+    'fall',
+    { year: 2027, month: 2, day: 22 },
+    { year: 2027, month: 8, day: 19 },
+    { year: 2027, month: 12, day: 11 }
+  ),
+  // 2028 (projected from ASU calendar patterns)
+  term(
+    2028,
+    'spring',
+    { year: 2027, month: 9, day: 20 },
+    { year: 2028, month: 1, day: 10 },
+    { year: 2028, month: 5, day: 7 }
+  ),
+  term(
+    2028,
+    'summer',
+    { year: 2028, month: 2, day: 3 },
+    { year: 2028, month: 5, day: 15 },
+    { year: 2028, month: 8, day: 12 }
+  ),
+  term(
+    2028,
+    'fall',
+    { year: 2028, month: 2, day: 21 },
+    { year: 2028, month: 8, day: 17 },
+    { year: 2028, month: 12, day: 10 }
+  ),
+];
+
+function term(
+  year: number,
+  season: AsuSeason,
+  catalogAvailable: DateParts,
+  sessionStart: DateParts,
+  sessionEnd: DateParts
+): AsuTerm {
+  const code = encodeTermCode(year, season);
+  return {
+    code,
+    label: `${SEASON_LABEL[season]} ${year}`,
+    season,
+    year,
+    catalogAvailable,
+    sessionStart,
+    sessionEnd,
+  };
+}
+
+/** Encode an ASU term code from year and season (e.g. 2026, "spring" → "2261"). */
+export function encodeTermCode(year: number, season: AsuSeason): string {
+  const yy = year % 100;
+  return `2${String(yy).padStart(2, '0')}${SEASON_SUFFIX[season]}`;
+}
+
+/** Compare two calendar dates (ignores time). Returns negative if a < b. */
+export function compareDateParts(a: DateParts, b: DateParts): number {
+  if (a.year !== b.year) return a.year - b.year;
+  if (a.month !== b.month) return a.month - b.month;
+  return a.day - b.day;
+}
+
+/** Extract today's date in America/Phoenix. */
+export function getPhoenixDateParts(now: Date = new Date()): DateParts {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: ASU_TIMEZONE,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  });
+
+  const parts = formatter.formatToParts(now);
+  const lookup = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? 0);
+
+  return {
+    year: lookup('year'),
+    month: lookup('month'),
+    day: lookup('day'),
+  };
+}
+
+function isOnOrAfter(today: DateParts, target: DateParts): boolean {
+  return compareDateParts(today, target) >= 0;
+}
+
+function isOnOrBefore(today: DateParts, target: DateParts): boolean {
+  return compareDateParts(today, target) <= 0;
+}
+
+function isInSession(term: AsuTerm, today: DateParts): boolean {
+  return isOnOrAfter(today, term.sessionStart) && isOnOrBefore(today, term.sessionEnd);
+}
+
+function isSelectable(term: AsuTerm, today: DateParts): boolean {
+  return isOnOrAfter(today, term.catalogAvailable) && isOnOrBefore(today, term.sessionEnd);
+}
+
+function getNextSeason(season: AsuSeason, year: number): { season: AsuSeason; year: number } {
+  switch (season) {
+    case 'fall':
+      return { season: 'spring', year: year + 1 };
+    case 'spring':
+      return { season: 'summer', year };
+    case 'summer':
+      return { season: 'fall', year };
+  }
+}
+
+function findTerm(season: AsuSeason, year: number): AsuTerm | undefined {
+  return ASU_TERM_CALENDAR.find((t) => t.season === season && t.year === year);
+}
+
+function findTermByCode(code: string): AsuTerm | undefined {
+  return ASU_TERM_CALENDAR.find((t) => t.code === code);
+}
+
+/**
+ * Returns the current and next selectable terms (1–2 items).
+ * Current = in-session term, or earliest upcoming selectable during gaps.
+ * Next = following season in the Fall → Spring → Summer cycle that is also selectable.
+ */
+export function getSelectableTerms(now: Date = new Date()): AsuTerm[] {
+  const today = getPhoenixDateParts(now);
+  const selectable = ASU_TERM_CALENDAR.filter((t) => isSelectable(t, today));
+
+  if (selectable.length === 0) {
+    return [];
+  }
+
+  const inSession = selectable.find((t) => isInSession(t, today));
+  const current = inSession ?? selectable[0];
+
+  const { season: nextSeason, year: nextYear } = getNextSeason(current.season, current.year);
+  const nextCandidate = findTerm(nextSeason, nextYear);
+
+  if (nextCandidate && isSelectable(nextCandidate, today) && nextCandidate.code !== current.code) {
+    return [current, nextCandidate];
+  }
+
+  return [current];
+}
+
+/** Whether a term code is currently selectable in the class picker. */
+export function isTermSelectable(code: string, now: Date = new Date()): boolean {
+  const termEntry = findTermByCode(code);
+  if (!termEntry) {
+    return false;
+  }
+
+  const today = getPhoenixDateParts(now);
+  return isSelectable(termEntry, today);
+}
+
+/** Format a term for display in the dropdown (e.g. "Fall 2026 (2267)"). */
+export function formatTermOption(termEntry: AsuTerm): string {
+  return `${termEntry.label} (${termEntry.code})`;
+}

--- a/tests/integration/api/class-watches.test.ts
+++ b/tests/integration/api/class-watches.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DELETE, GET, POST } from '@/app/api/class-watches/route';
 import type { ValidationIssueDetail } from '@/lib/api/validation';
 
@@ -184,9 +184,15 @@ async function parseDeleteResponse(response: Response): Promise<DeleteResponse> 
 
 describe('/api/class-watches', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
     vi.clearAllMocks();
     setupMockChain();
     mockRpc.mockResolvedValue({ data: mockWatch, error: null });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('GET /api/class-watches', () => {

--- a/tests/integration/api/class-watches.test.ts
+++ b/tests/integration/api/class-watches.test.ts
@@ -49,7 +49,7 @@ const mockUser = { id: 'user-123', email: 'test@example.com' };
 const mockWatch: ClassWatch = {
   id: 'watch-1',
   user_id: 'user-123',
-  term: '2261',
+  term: '2264',
   subject: 'CSE',
   catalog_nbr: '240',
   class_nbr: '12345',
@@ -57,7 +57,7 @@ const mockWatch: ClassWatch = {
 };
 const mockClassState: ClassState = {
   class_nbr: '12345',
-  term: '2261',
+  term: '2264',
   subject: 'CSE',
   catalog_nbr: '240',
   title: 'Intro to Programming',
@@ -251,7 +251,7 @@ describe('/api/class-watches', () => {
     it('should return 401 for unauthenticated requests', async () => {
       mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'Unauthorized' } });
 
-      const request = createRequest({ term: '2261', class_nbr: '12345' });
+      const request = createRequest({ term: '2264', class_nbr: '12345' });
       const response = await POST(request);
       const data = await parsePostResponse(response);
 
@@ -284,7 +284,7 @@ describe('/api/class-watches', () => {
         eq: vi.fn().mockResolvedValue({ count: 0, error: null }),
       });
 
-      const request = createRequest({ term: '2261', class_nbr: '123' });
+      const request = createRequest({ term: '2264', class_nbr: '123' });
       const response = await POST(request);
       const data = await parsePostResponse(response);
 
@@ -299,7 +299,7 @@ describe('/api/class-watches', () => {
         eq: vi.fn().mockResolvedValue({ count: 10, error: null }),
       });
 
-      const request = createRequest({ term: '2261', class_nbr: '12345' });
+      const request = createRequest({ term: '2264', class_nbr: '12345' });
       const response = await POST(request);
       const data = await parsePostResponse(response);
 
@@ -318,7 +318,7 @@ describe('/api/class-watches', () => {
         error: { code: '23505', message: 'Unique constraint violation' },
       });
 
-      const request = createRequest({ term: '2261', class_nbr: '12345' });
+      const request = createRequest({ term: '2264', class_nbr: '12345' });
       const response = await POST(request);
       const data = await parsePostResponse(response);
 
@@ -337,7 +337,7 @@ describe('/api/class-watches', () => {
         error: { code: 'P0001', message: 'MAX_WATCHES_EXCEEDED' },
       });
 
-      const request = createRequest({ term: '2261', class_nbr: '12345' });
+      const request = createRequest({ term: '2264', class_nbr: '12345' });
       const response = await POST(request);
       const data = await parsePostResponse(response);
 
@@ -353,7 +353,7 @@ describe('/api/class-watches', () => {
 
       mockFetchClassFromASU.mockRejectedValue(new Error('Network error'));
 
-      const request = createRequest({ term: '2261', class_nbr: '12345' });
+      const request = createRequest({ term: '2264', class_nbr: '12345' });
       const response = await POST(request);
       const data = await parsePostResponse(response);
 
@@ -371,7 +371,7 @@ describe('/api/class-watches', () => {
       const { NotFoundError } = await import('@/lib/asu/api');
       mockFetchClassFromASU.mockRejectedValue(new NotFoundError('Section 99999 not found'));
 
-      const request = createRequest({ term: '2261', class_nbr: '99999' });
+      const request = createRequest({ term: '2264', class_nbr: '99999' });
       const response = await POST(request);
       const data = await parsePostResponse(response);
 
@@ -388,7 +388,7 @@ describe('/api/class-watches', () => {
       const { AuthError } = await import('@/lib/asu/api');
       mockFetchClassFromASU.mockRejectedValue(new AuthError('Token expired'));
 
-      const request = createRequest({ term: '2261', class_nbr: '12345' });
+      const request = createRequest({ term: '2264', class_nbr: '12345' });
       const response = await POST(request);
       const data = await parsePostResponse(response);
 
@@ -405,13 +405,13 @@ describe('/api/class-watches', () => {
       mockFetchClassFromASU.mockResolvedValue(mockClassDetails);
       mockRpc.mockResolvedValue({ data: mockWatch, error: null });
 
-      const request = createRequest({ term: '2261', class_nbr: '12345' });
+      const request = createRequest({ term: '2264', class_nbr: '12345' });
       const response = await POST(request);
       const data = await parsePostResponse(response);
 
       expect(response.status).toBe(201);
       expect(data.watch).toBeDefined();
-      expect(mockFetchClassFromASU).toHaveBeenCalledWith('12345', '2261', {
+      expect(mockFetchClassFromASU).toHaveBeenCalledWith('12345', '2264', {
         ASU_API_BASE_URL: expect.any(String),
         ASU_API_TOKEN: expect.any(String),
       });
@@ -419,7 +419,7 @@ describe('/api/class-watches', () => {
         'create_class_watch_with_limit',
         expect.objectContaining({
           p_user_id: mockUser.id,
-          p_term: '2261',
+          p_term: '2264',
           p_class_nbr: '12345',
         })
       );

--- a/tests/integration/api/fetch-class-details.test.ts
+++ b/tests/integration/api/fetch-class-details.test.ts
@@ -81,7 +81,7 @@ describe('/api/fetch-class-details', () => {
   });
 
   it('rejects invalid class detail requests', async () => {
-    const response = await POST(request({ term: '2261', class_nbr: 'abc' }));
+    const response = await POST(request({ term: '2264', class_nbr: 'abc' }));
     const data = await json(response);
 
     expect(response.status).toBe(400);
@@ -90,7 +90,7 @@ describe('/api/fetch-class-details', () => {
   });
 
   it('fetches ASU details, persists the class state, and returns display data', async () => {
-    const response = await POST(request({ term: '2261', class_nbr: '12345' }));
+    const response = await POST(request({ term: '2264', class_nbr: '12345' }));
     const data = await json(response);
 
     expect(response.status).toBe(200);
@@ -100,13 +100,13 @@ describe('/api/fetch-class-details', () => {
       instructor_name: 'Dr. Smith',
       seats_available: 7,
     });
-    expect(mockFetchClassFromASU).toHaveBeenCalledWith('12345', '2261', {
+    expect(mockFetchClassFromASU).toHaveBeenCalledWith('12345', '2264', {
       ASU_API_BASE_URL: 'https://classes.example.test',
       ASU_API_TOKEN: 'test-token',
     });
     expect(mockUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        term: '2261',
+        term: '2264',
         class_nbr: '12345',
         non_reserved_seats: 3,
       }),
@@ -117,7 +117,7 @@ describe('/api/fetch-class-details', () => {
   it('maps ASU not-found errors to 404', async () => {
     mockFetchClassFromASU.mockRejectedValueOnce(new NotFoundError('missing'));
 
-    const response = await POST(request({ term: '2261', class_nbr: '12345' }));
+    const response = await POST(request({ term: '2264', class_nbr: '12345' }));
     const data = await json(response);
 
     expect(response.status).toBe(404);
@@ -127,7 +127,7 @@ describe('/api/fetch-class-details', () => {
   it('maps ASU auth failures to a temporary service outage', async () => {
     mockFetchClassFromASU.mockRejectedValueOnce(new AuthError('expired token'));
 
-    const response = await POST(request({ term: '2261', class_nbr: '12345' }));
+    const response = await POST(request({ term: '2264', class_nbr: '12345' }));
     const data = await json(response);
 
     expect(response.status).toBe(503);
@@ -137,7 +137,7 @@ describe('/api/fetch-class-details', () => {
   it('maps unexpected ASU failures to a fetch error', async () => {
     mockFetchClassFromASU.mockRejectedValueOnce(new Error('network down'));
 
-    const response = await POST(request({ term: '2261', class_nbr: '12345' }));
+    const response = await POST(request({ term: '2264', class_nbr: '12345' }));
     const data = await json(response);
 
     expect(response.status).toBe(500);
@@ -147,7 +147,7 @@ describe('/api/fetch-class-details', () => {
   it('still returns class details when persistence returns an error', async () => {
     mockUpsert.mockResolvedValueOnce({ error: { message: 'write failed' } });
 
-    const response = await POST(request({ term: '2261', class_nbr: '12345' }));
+    const response = await POST(request({ term: '2264', class_nbr: '12345' }));
     const data = await json(response);
 
     expect(response.status).toBe(200);
@@ -159,7 +159,7 @@ describe('/api/fetch-class-details', () => {
       throw new Error('service client unavailable');
     });
 
-    const response = await POST(request({ term: '2261', class_nbr: '12345' }));
+    const response = await POST(request({ term: '2264', class_nbr: '12345' }));
     const data = await json(response);
 
     expect(response.status).toBe(200);

--- a/tests/unit/components/interaction-components.test.tsx
+++ b/tests/unit/components/interaction-components.test.tsx
@@ -11,6 +11,32 @@ const { mockPathname, mockPush } = vi.hoisted(() => ({
   mockPush: vi.fn(),
 }));
 
+const mockSelectableTerms = vi.hoisted(() => [
+  {
+    code: '2264',
+    label: 'Summer 2026',
+    season: 'summer' as const,
+    year: 2026,
+    catalogAvailable: { year: 2026, month: 2, day: 5 },
+    sessionStart: { year: 2026, month: 5, day: 18 },
+    sessionEnd: { year: 2026, month: 8, day: 14 },
+  },
+  {
+    code: '2267',
+    label: 'Fall 2026',
+    season: 'fall' as const,
+    year: 2026,
+    catalogAvailable: { year: 2026, month: 2, day: 23 },
+    sessionStart: { year: 2026, month: 8, day: 20 },
+    sessionEnd: { year: 2026, month: 12, day: 12 },
+  },
+]);
+
+vi.mock('@/lib/asu/terms', () => ({
+  getSelectableTerms: () => mockSelectableTerms,
+  formatTermOption: (term: { label: string; code: string }) => `${term.label} (${term.code})`,
+}));
+
 vi.mock('next/link', () => ({
   default: ({
     href,
@@ -158,14 +184,6 @@ describe('interactive components', () => {
     const onAdd = vi.fn().mockResolvedValue(undefined);
     render(<AddClassWatch onAdd={onAdd} />);
 
-    fireEvent.submit(screen.getByRole('button', { name: /start watching/i }).closest('form')!);
-    expect(
-      await screen.findByText('Please select a term and enter a section number')
-    ).toBeInTheDocument();
-
-    fireEvent.change(screen.getByRole('combobox', { name: /term/i }), {
-      target: { value: '2264' },
-    });
     fireEvent.change(screen.getByLabelText(/section number/i), { target: { value: '123' } });
     fireEvent.submit(screen.getByRole('button', { name: /start watching/i }).closest('form')!);
     expect(await screen.findByText('Section number must be exactly 5 digits')).toBeInTheDocument();
@@ -179,9 +197,6 @@ describe('interactive components', () => {
     const onAdd = vi.fn().mockRejectedValue(new Error('Class already watched'));
     render(<AddClassWatch onAdd={onAdd} />);
 
-    fireEvent.change(screen.getByRole('combobox', { name: /term/i }), {
-      target: { value: '2264' },
-    });
     fireEvent.change(screen.getByLabelText(/section number/i), { target: { value: '12345' } });
     fireEvent.submit(screen.getByRole('button', { name: /start watching/i }).closest('form')!);
 

--- a/tests/unit/lib/asu-terms.test.ts
+++ b/tests/unit/lib/asu-terms.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createClassWatchSchema } from '@/lib/api/schemas';
+import {
+  encodeTermCode,
+  formatTermOption,
+  getSelectableTerms,
+  isTermSelectable,
+} from '@/lib/asu/terms';
+
+function phoenixDate(year: number, month: number, day: number): Date {
+  // Noon UTC avoids edge cases around midnight in America/Phoenix (UTC-7, no DST)
+  return new Date(Date.UTC(year, month - 1, day, 19, 0, 0));
+}
+
+function termCodes(terms: ReturnType<typeof getSelectableTerms>): string[] {
+  return terms.map((t) => t.code);
+}
+
+describe('encodeTermCode', () => {
+  it('encodes spring, summer, and fall term codes', () => {
+    expect(encodeTermCode(2026, 'spring')).toBe('2261');
+    expect(encodeTermCode(2026, 'summer')).toBe('2264');
+    expect(encodeTermCode(2026, 'fall')).toBe('2267');
+  });
+});
+
+describe('formatTermOption', () => {
+  it('formats term for dropdown display', () => {
+    const terms = getSelectableTerms(phoenixDate(2026, 5, 23));
+    expect(formatTermOption(terms[0])).toMatch(/\(2264\)/);
+  });
+});
+
+describe('getSelectableTerms', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns Spring 2026 only before Summer catalog is available', () => {
+    vi.setSystemTime(phoenixDate(2026, 1, 15));
+    expect(termCodes(getSelectableTerms())).toEqual(['2261']);
+  });
+
+  it('returns Spring and Summer when both are selectable', () => {
+    vi.setSystemTime(phoenixDate(2026, 2, 10));
+    expect(termCodes(getSelectableTerms())).toEqual(['2261', '2264']);
+  });
+
+  it('returns Summer and Fall during Summer session', () => {
+    vi.setSystemTime(phoenixDate(2026, 5, 23));
+    expect(termCodes(getSelectableTerms())).toEqual(['2264', '2267']);
+  });
+
+  it('returns Fall only before Spring catalog is available', () => {
+    vi.setSystemTime(phoenixDate(2026, 8, 25));
+    expect(termCodes(getSelectableTerms())).toEqual(['2267']);
+  });
+
+  it('returns Fall and Spring 2027 when both are selectable', () => {
+    vi.setSystemTime(phoenixDate(2026, 9, 25));
+    expect(termCodes(getSelectableTerms())).toEqual(['2267', '2271']);
+  });
+
+  it('returns Spring 2027 only during winter gap', () => {
+    vi.setSystemTime(phoenixDate(2026, 12, 20));
+    expect(termCodes(getSelectableTerms())).toEqual(['2271']);
+  });
+
+  it('never returns more than two terms', () => {
+    vi.setSystemTime(phoenixDate(2026, 5, 23));
+    expect(getSelectableTerms().length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('isTermSelectable', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns true for a currently selectable term', () => {
+    vi.setSystemTime(phoenixDate(2026, 5, 23));
+    expect(isTermSelectable('2264')).toBe(true);
+    expect(isTermSelectable('2267')).toBe(true);
+  });
+
+  it('returns false for an expired term', () => {
+    vi.setSystemTime(phoenixDate(2026, 5, 23));
+    expect(isTermSelectable('2261')).toBe(false);
+  });
+
+  it('returns false for unknown term codes', () => {
+    vi.setSystemTime(phoenixDate(2026, 5, 23));
+    expect(isTermSelectable('9999')).toBe(false);
+  });
+});
+
+describe('createClassWatchSchema term validation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(phoenixDate(2026, 5, 23));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('accepts a selectable term', () => {
+    const result = createClassWatchSchema.safeParse({ term: '2264', class_nbr: '12345' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an expired term', () => {
+    const result = createClassWatchSchema.safeParse({ term: '2261', class_nbr: '12345' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('no longer available');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Replace hardcoded term dropdown options with calendar-driven logic that shows only the current and next selectable ASU terms (1–2 max)
- Add `lib/asu/terms.ts` with ASU academic calendar dates (2025–2028) and server-side validation to reject expired terms on new watch creation
- Keep queue processing on past terms via a separate format-only schema so existing watches continue to work

## Test plan

- [x] `bun run test:run` — 609 tests pass
- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean
- [x] Unit tests cover term transitions (Jan gap, Feb dual-term, May Summer+Fall, Sep Fall+Spring, Dec gap)
- [ ] Manual: open `/dashboard/add` and confirm Summer 2026 + Fall 2026 appear with Summer pre-selected