### PR TITLE
refactor: remove dead admin-query code and test-only lock helper

### DIFF
--- a/lib/db/admin-queries.ts
+++ b/lib/db/admin-queries.ts
@@ -7,7 +7,6 @@
  * @module lib/db/admin-queries
  */
 
-import type { User } from '@supabase/supabase-js';
 import { TtlCache } from '@/lib/cache/ttl-cache';
 import { ADMIN_CACHE_TTL_MS } from '@/lib/config';
 import { log } from '@/lib/log';
@@ -15,14 +14,6 @@ import type { Tables } from '@/lib/supabase/database.types';
 import { getServiceClient } from '@/lib/supabase/service';
 
 const adminCache = new TtlCache<unknown>(ADMIN_CACHE_TTL_MS);
-
-/**
- * Email notification counts (seat and instructor)
- */
-interface EmailCounts {
-  seat_emails: number;
-  instructor_emails: number;
-}
 
 /**
  * Class state with aggregated watcher count
@@ -63,136 +54,6 @@ export interface UserWithWatchCount {
  */
 interface WatchWithClass extends Tables<'class_watches'> {
   class_state: Tables<'class_states'> | null;
-}
-
-/**
- * RPC response type for engagement stats
- */
-interface EngagementStatsRow {
-  user_id: string;
-  engagement_emails_sent: number;
-  engagement_emails_opened: number;
-  engagement_rate: number | null;
-  engagement_status: EngagementStatus;
-}
-
-async function fetchAllAuthUsers(): Promise<User[]> {
-  const supabase = getServiceClient();
-  const perPage = 1000;
-  const maxPages = 50; // Cap at 50,000 users
-  let page = 1;
-  const users: User[] = [];
-
-  while (page <= maxPages) {
-    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
-
-    if (error) {
-      console.error('[Admin] Error fetching users:', error);
-      throw new Error(`Failed to fetch users: ${error.message}`);
-    }
-
-    const batch = data?.users || [];
-    users.push(...batch);
-
-    if (batch.length < perPage) {
-      break;
-    }
-
-    page += 1;
-  }
-
-  if (page > maxPages) {
-    console.warn(`[Admin] User fetch capped at ${maxPages * perPage} users`);
-  }
-
-  return users;
-}
-
-/**
- * Get notification counts grouped by class number
- *
- * Calls the get_notification_counts_by_class RPC function to aggregate
- * seat_available and instructor_assigned notification counts per class.
- *
- * @returns Map of class_nbr to EmailCounts
- */
-async function getNotificationCountsByClass(): Promise<Map<string, EmailCounts>> {
-  const supabase = getServiceClient();
-
-  const { data, error } = await supabase.rpc('get_notification_counts_by_class');
-
-  if (error) {
-    console.error('[Admin] Error fetching notification counts by class:', error);
-    throw new Error(`Failed to fetch notification counts by class: ${error.message}`);
-  }
-
-  const countsMap = new Map<string, EmailCounts>();
-  for (const row of data || []) {
-    countsMap.set(row.class_nbr, {
-      seat_emails: row.seat_emails || 0,
-      instructor_emails: row.instructor_emails || 0,
-    });
-  }
-
-  return countsMap;
-}
-
-/**
- * Get notification counts grouped by user ID
- *
- * Calls the get_notification_counts_by_user RPC function to aggregate
- * seat_available and instructor_assigned notification counts per user.
- *
- * @returns Map of user_id to EmailCounts
- */
-async function getNotificationCountsByUser(): Promise<Map<string, EmailCounts>> {
-  const supabase = getServiceClient();
-
-  const { data, error } = await supabase.rpc('get_notification_counts_by_user');
-
-  if (error) {
-    console.error('[Admin] Error fetching notification counts by user:', error);
-    throw new Error(`Failed to fetch notification counts by user: ${error.message}`);
-  }
-
-  const countsMap = new Map<string, EmailCounts>();
-  for (const row of data || []) {
-    countsMap.set(row.user_id, {
-      seat_emails: row.seat_emails || 0,
-      instructor_emails: row.instructor_emails || 0,
-    });
-  }
-
-  return countsMap;
-}
-
-/**
- * Get engagement statistics for all users
- *
- * Calls the get_user_engagement_stats RPC function to retrieve
- * engagement tracking data for admin dashboard.
- *
- * @returns Map of user_id to engagement stats
- */
-async function getEngagementStats(): Promise<Map<string, EngagementStatsRow>> {
-  const supabase = getServiceClient();
-
-  const { data, error } = await supabase.rpc('get_user_engagement_stats');
-
-  if (error) {
-    console.error('[Admin] Error fetching engagement stats:', error);
-    throw new Error(`Failed to fetch engagement stats: ${error.message}`);
-  }
-
-  const statsMap = new Map<string, EngagementStatsRow>();
-  for (const row of data || []) {
-    statsMap.set(row.user_id, {
-      ...row,
-      engagement_status: row.engagement_status as EngagementStatus,
-    });
-  }
-
-  return statsMap;
 }
 
 /**
@@ -378,8 +239,7 @@ export interface ClassesPage {
  * Get a single page of users for the admin dashboard
  *
  * Calls get_users_page RPC which applies all filter/sort dimensions in SQL
- * and returns only the requested page of rows. Replaces getAllUsersWithWatchCount
- * for the table render path.
+ * and returns only the requested page of rows for the table render path.
  *
  * @param params - Page, sort, and filter parameters
  * @returns Paginated result with rows and total matching count
@@ -441,8 +301,7 @@ export async function getUsersPage(params: GetUsersPageParams = {}): Promise<Use
  * Get a single page of classes for the admin dashboard
  *
  * Calls get_classes_page RPC which applies all filter/sort dimensions in SQL
- * and returns only the requested page of rows. Replaces getAllClassesWithWatchers
- * for the table render path.
+ * and returns only the requested page of rows for the table render path.
  *
  * @param params - Page, sort, and filter parameters
  * @returns Paginated result with rows and total matching count
@@ -530,155 +389,6 @@ export async function getDistinctSubjects(): Promise<string[]> {
   const result = (data ?? []).map((r) => r.subject);
   adminCache.set('distinct-subjects', result);
   return result;
-}
-
-/**
- * Get all classes with their watcher counts
- *
- * Joins class_states with aggregated class_watches to show which classes
- * are most popular. Sorted by watcher count descending.
- *
- * @returns Array of classes with watcher counts
- *
- * @example
- * const classes = await getAllClassesWithWatchers()
- */
-export async function getAllClassesWithWatchers(): Promise<ClassWithWatchers[]> {
-  const cached = adminCache.get('classes-with-watchers') as ClassWithWatchers[] | undefined;
-  if (cached !== undefined) return cached;
-
-  const supabase = getServiceClient();
-
-  const [classStatesResult, watchesResult, notificationCounts] = await Promise.all([
-    supabase.from('class_states').select('*').order('class_nbr', { ascending: true }),
-    supabase.from('class_watches').select('class_nbr'),
-    getNotificationCountsByClass(),
-  ]);
-
-  const { data: classStates, error: classError } = classStatesResult;
-  const { data: watches, error: watchError } = watchesResult;
-
-  if (classError) {
-    console.error('[Admin] Error fetching class states:', classError);
-    throw new Error(`Failed to fetch classes: ${classError.message}`);
-  }
-
-  if (watchError) {
-    console.error('[Admin] Error fetching class watches:', watchError);
-    throw new Error(`Failed to fetch watches: ${watchError.message}`);
-  }
-
-  const watcherCountMap = new Map<string, number>();
-  for (const watch of watches || []) {
-    watcherCountMap.set(watch.class_nbr, (watcherCountMap.get(watch.class_nbr) || 0) + 1);
-  }
-
-  const classesWithWatchers: ClassWithWatchers[] = (classStates || [])
-    .map((classState) => {
-      const emailCounts = notificationCounts.get(classState.class_nbr);
-      return {
-        ...classState,
-        watcher_count: watcherCountMap.get(classState.class_nbr) || 0,
-        seat_emails: emailCounts?.seat_emails || 0,
-        instructor_emails: emailCounts?.instructor_emails || 0,
-      };
-    })
-    .sort((a, b) => b.watcher_count - a.watcher_count);
-
-  log('Admin').info(
-    `Fetched ${classesWithWatchers.length} classes with watcher counts (total watchers: ${watches?.length || 0})`
-  );
-
-  adminCache.set('classes-with-watchers', classesWithWatchers);
-  return classesWithWatchers;
-}
-
-/**
- * Get all users with their watch counts and admin status
- *
- * Retrieves all users from auth.users and joins with class_watches
- * and user_profiles to show how many classes each user is monitoring
- * and their admin status. Sorted by created_at descending.
- *
- * @returns Array of users with watch counts and admin status
- *
- * @example
- * const users = await getAllUsersWithWatchCount()
- */
-export async function getAllUsersWithWatchCount(): Promise<UserWithWatchCount[]> {
-  const cached = adminCache.get('users-with-watch-count') as UserWithWatchCount[] | undefined;
-  if (cached !== undefined) return cached;
-
-  const supabase = getServiceClient();
-
-  try {
-    const users = await fetchAllAuthUsers();
-
-    if (users.length === 0) {
-      return [];
-    }
-
-    const [watchCountsResult, profilesResult, notificationCounts, engagementStats] =
-      await Promise.all([
-        supabase.from('class_watches').select('user_id'),
-        supabase.from('user_profiles').select('user_id, is_admin'),
-        getNotificationCountsByUser(),
-        getEngagementStats(),
-      ]);
-
-    const { data: watchCounts, error: watchError } = watchCountsResult;
-    const { data: profiles, error: profileError } = profilesResult;
-
-    if (watchError) {
-      console.error('[Admin] Error fetching watch counts:', watchError);
-      throw new Error(`Failed to fetch watch counts: ${watchError.message}`);
-    }
-
-    if (profileError) {
-      console.error('[Admin] Error fetching user profiles:', profileError);
-      throw new Error(`Failed to fetch user profiles: ${profileError.message}`);
-    }
-
-    const watchCountMap = new Map<string, number>();
-    for (const watch of watchCounts || []) {
-      watchCountMap.set(watch.user_id, (watchCountMap.get(watch.user_id) || 0) + 1);
-    }
-
-    const adminStatusMap = new Map<string, boolean>();
-    for (const profile of profiles || []) {
-      adminStatusMap.set(profile.user_id, profile.is_admin);
-    }
-    const usersWithWatchCount: UserWithWatchCount[] = users
-      .map((user) => {
-        const emailCounts = notificationCounts.get(user.id);
-        const engagement = engagementStats.get(user.id);
-        return {
-          id: user.id,
-          email: user.email || '',
-          created_at: user.created_at,
-          last_sign_in_at: user.last_sign_in_at || null,
-          email_confirmed_at: user.email_confirmed_at || null,
-          watch_count: watchCountMap.get(user.id) || 0,
-          is_admin: adminStatusMap.get(user.id) || false,
-          seat_emails: emailCounts?.seat_emails || 0,
-          instructor_emails: emailCounts?.instructor_emails || 0,
-          // Engagement tracking
-          engagement_emails_sent: engagement?.engagement_emails_sent || 0,
-          engagement_emails_opened: engagement?.engagement_emails_opened || 0,
-          engagement_rate: engagement?.engagement_rate ?? null,
-          engagement_status: engagement?.engagement_status || 'new',
-        };
-      })
-      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-
-    log('Admin').info(`Fetched ${usersWithWatchCount.length} users with watch counts`);
-
-    adminCache.set('users-with-watch-count', usersWithWatchCount);
-    return usersWithWatchCount;
-  } catch (err) {
-    console.error('[Admin] Exception fetching users with watch counts:', err);
-    throw err;
-  }
 }
 
 /**

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -18,7 +18,6 @@ export interface ClassWatcher {
   email: string;
   watch_id: string;
   created_at?: string; // Optional for backward compatibility
-  class_nbr?: string; // Added for bulk fetching
 }
 
 /**

--- a/tests/unit/lib/db/admin-dashboard-queries.test.ts
+++ b/tests/unit/lib/db/admin-dashboard-queries.test.ts
@@ -34,8 +34,6 @@ vi.mock('@/lib/cache/ttl-cache', () => ({
 
 import {
   getAdminCount,
-  getAllClassesWithWatchers,
-  getAllUsersWithWatchCount,
   getClassesPage,
   getTotalClassesWatched,
   getTotalEmailsSent,
@@ -162,32 +160,6 @@ describe('admin dashboard query helpers', () => {
     });
 
     mockServiceClient.rpc.mockImplementation((name: string, _args?: unknown) => {
-      if (name === 'get_notification_counts_by_class') {
-        return Promise.resolve({
-          data: [{ class_nbr: '12345', seat_emails: 4, instructor_emails: 1 }],
-          error: null,
-        });
-      }
-      if (name === 'get_notification_counts_by_user') {
-        return Promise.resolve({
-          data: [{ user_id: 'user-2', seat_emails: 3, instructor_emails: 2 }],
-          error: null,
-        });
-      }
-      if (name === 'get_user_engagement_stats') {
-        return Promise.resolve({
-          data: [
-            {
-              user_id: 'user-2',
-              engagement_emails_sent: 5,
-              engagement_emails_opened: 4,
-              engagement_rate: 0.8,
-              engagement_status: 'healthy',
-            },
-          ],
-          error: null,
-        });
-      }
       // New scalar RPCs
       if (name === 'count_all_users') {
         return Promise.resolve({ data: 2, error: null });
@@ -213,45 +185,6 @@ describe('admin dashboard query helpers', () => {
       (c) => c[0] === 'class_watches'
     );
     expect(classWatchCalls.length).toBe(0);
-
-    const classes = await getAllClassesWithWatchers();
-    expect(classes).toMatchObject([
-      {
-        class_nbr: '12345',
-        watcher_count: 2,
-        seat_emails: 4,
-        instructor_emails: 1,
-      },
-      {
-        class_nbr: '67890',
-        watcher_count: 1,
-        seat_emails: 0,
-        instructor_emails: 0,
-      },
-    ]);
-
-    const usersWithCounts = await getAllUsersWithWatchCount();
-    expect(usersWithCounts).toMatchObject([
-      {
-        id: 'user-2',
-        email: 'two@example.com',
-        watch_count: 2,
-        is_admin: false,
-        seat_emails: 3,
-        instructor_emails: 2,
-        engagement_emails_sent: 5,
-        engagement_emails_opened: 4,
-        engagement_rate: 0.8,
-        engagement_status: 'healthy',
-      },
-      {
-        id: 'user-1',
-        email: 'one@example.com',
-        watch_count: 1,
-        is_admin: true,
-        engagement_status: 'new',
-      },
-    ]);
 
     const userWatches = await getUserWatches('user-2');
     expect(userWatches).toHaveLength(3);

--- a/tests/unit/pages/admin-pages.test.tsx
+++ b/tests/unit/pages/admin-pages.test.tsx
@@ -10,8 +10,6 @@ import AdminUsersPage from '@/app/admin/users/page';
 
 const {
   mockGetAdminCount,
-  mockGetAllClassesWithWatchers,
-  mockGetAllUsersWithWatchCount,
   mockGetClassWatchers,
   mockGetClassesPage,
   mockGetDistinctSubjects,
@@ -26,8 +24,6 @@ const {
   mockVerifyAdmin,
 } = vi.hoisted(() => ({
   mockGetAdminCount: vi.fn(),
-  mockGetAllClassesWithWatchers: vi.fn(),
-  mockGetAllUsersWithWatchCount: vi.fn(),
   mockGetClassWatchers: vi.fn(),
   mockGetClassesPage: vi.fn(),
   mockGetDistinctSubjects: vi.fn(),
@@ -102,8 +98,6 @@ vi.mock('@/lib/supabase/service', () => ({
 
 vi.mock('@/lib/db/admin-queries', () => ({
   getAdminCount: mockGetAdminCount,
-  getAllClassesWithWatchers: mockGetAllClassesWithWatchers,
-  getAllUsersWithWatchCount: mockGetAllUsersWithWatchCount,
   getClassesPage: mockGetClassesPage,
   getDistinctSubjects: mockGetDistinctSubjects,
   getRecentActivity: mockGetRecentActivity,
@@ -251,9 +245,6 @@ describe('admin pages', () => {
         notificationType: 'seat_available',
       },
     ]);
-    // Legacy whole-table functions (still used by dashboard/detail pages)
-    mockGetAllClassesWithWatchers.mockResolvedValue(classRows);
-    mockGetAllUsersWithWatchCount.mockResolvedValue(userRows);
     // New paginated functions
     mockGetUsersPage.mockResolvedValue({ rows: userRows, total: userRows.length });
     mockGetClassesPage.mockResolvedValue({ rows: classRows, total: classRows.length });

--- a/tests/unit/worker/cron-lock-do.test.ts
+++ b/tests/unit/worker/cron-lock-do.test.ts
@@ -173,29 +173,6 @@ describe('CronLockDO', () => {
     });
   });
 
-  // ── forceRelease ──────────────────────────────────────────────────────────
-
-  describe('forceRelease', () => {
-    it('unlocks even when a different holder has the lock', async () => {
-      const do_ = makeDO();
-      await do_.acquireLock('worker-a');
-
-      await do_.forceRelease();
-
-      const status = await do_.getStatus();
-      expect(status.locked).toBe(false);
-    });
-
-    it('is a no-op when lock is already free', async () => {
-      const do_ = makeDO();
-      // Should not throw
-      await expect(do_.forceRelease()).resolves.toBeUndefined();
-
-      const status = await do_.getStatus();
-      expect(status.locked).toBe(false);
-    });
-  });
-
   // ── HTTP fetch dispatcher ─────────────────────────────────────────────────
 
   describe('fetch dispatcher', () => {
@@ -248,29 +225,6 @@ describe('CronLockDO', () => {
       expect(body.locked).toBe(false);
     });
 
-    it('POST /force-release unlocks and returns success', async () => {
-      const do_ = makeDO();
-      await do_.acquireLock('worker-a');
-
-      const req = new Request('http://localhost/force-release', { method: 'POST' });
-      const resp = await do_.fetch(req);
-
-      expect(resp.status).toBe(200);
-      const body = (await resp.json()) as { success: boolean };
-      expect(body.success).toBe(true);
-
-      const status = await do_.getStatus();
-      expect(status.locked).toBe(false);
-    });
-
-    it('GET /force-release returns 405', async () => {
-      const do_ = makeDO();
-      const req = new Request('http://localhost/force-release', { method: 'GET' });
-      const resp = await do_.fetch(req);
-
-      expect(resp.status).toBe(405);
-    });
-
     it('unknown path returns 404', async () => {
       const do_ = makeDO();
       const req = new Request('http://localhost/unknown-path', { method: 'GET' });
@@ -316,16 +270,6 @@ describe('CronLockDO', () => {
       const do_ = new CronLockDO(ctx, {} as Cloudflare.Env);
       await do_.acquireLock('worker-a');
       await do_.releaseLock('worker-a');
-
-      const stored = await ctx.storage.get<{ locked: boolean }>('lock_state');
-      expect(stored?.locked).toBe(false);
-    });
-
-    it('persists unlocked state on forceRelease', async () => {
-      const ctx = makeFakeCtx();
-      const do_ = new CronLockDO(ctx, {} as Cloudflare.Env);
-      await do_.acquireLock('worker-a');
-      await do_.forceRelease();
 
       const stored = await ctx.storage.get<{ locked: boolean }>('lock_state');
       expect(stored?.locked).toBe(false);

--- a/worker.ts
+++ b/worker.ts
@@ -250,17 +250,6 @@ export class CronLockDO extends DurableObject<Cloudflare.Env> {
   }
 
   /**
-   * Force release lock (admin/testing only)
-   */
-  async forceRelease(): Promise<void> {
-    console.log(`[CronLockDO] Force release requested`);
-    this.locked = false;
-    this.lockAcquiredAt = null;
-    this.lockHolder = null;
-    await this.persist();
-  }
-
-  /**
    * Fetch handler - provides HTTP API for lock operations
    */
   async fetch(request: Request): Promise<Response> {
@@ -282,13 +271,6 @@ export class CronLockDO extends DurableObject<Cloudflare.Env> {
 
       case '/status':
         return Response.json(await this.getStatus());
-
-      case '/force-release':
-        if (request.method !== 'POST') {
-          return new Response('Method not allowed', { status: 405 });
-        }
-        await this.forceRelease();
-        return Response.json({ success: true, message: 'Lock force released' });
 
       default:
         return new Response('Not found', { status: 404 });


### PR DESCRIPTION
## Summary

Deletes unreachable code surfaced by an over-engineering audit of the repo. **No production behavior change** — the live admin dashboard path and the cron lock are both untouched. This is pure dead-code removal (knip cannot flag it because the code was reachable only from tests).

## What was removed

**`lib/db/admin-queries.ts`**
- `getAllUsersWithWatchCount` / `getAllClassesWithWatchers` — superseded by the `get_users_page` / `get_classes_page` RPC wrappers; the admin pages already use the paginated versions.
- Orphaned helpers whose only callers were the two functions above: `fetchAllAuthUsers`, `getEngagementStats`, `getNotificationCountsByUser`, `getNotificationCountsByClass`.
- `EmailCounts` and `EngagementStatsRow` interfaces + the now-unused `import type { User }`.
- Fixed two stale docstrings that referenced the deleted functions.

**`lib/db/queries.ts`**
- Dropped the unused `ClassWatcher.class_nbr` field. (`created_at` was kept — it is used by the class-detail page.)

**`worker.ts`**
- Removed `CronLockDO.forceRelease()` and its `/force-release` dispatcher case — test-only break-glass with no production caller. The lock still auto-expires after 25 min.

**Tests** — pruned references to the removed symbols in `admin-dashboard-queries.test.ts`, `admin-pages.test.tsx`, and `cron-lock-do.test.ts`.

## Verification

- `bun run type-check` (app + worker tsconfigs) ✅
- `bun run knip` (clean) ✅
- `bun run test:run` — **690 passed (59 files), 0 failures** ✅
- `bun run build` — build complete ✅
- `bun run check` (format + lint + types) ✅

## Out of scope (intentionally not done)
- CronLockDO self-`fetch` → native DO RPC refactor (it is a rewrite of working safety-critical code, not dead code).
- The 3 corresponding Postgres RPCs are now unused by app code but left in place — dropping them needs a new migration and applied migrations are never edited.

Net: **+2 / −443** lines.
