### PR TITLE
feat(domain): add SectionRef value type + query/key/equality helpers (#275)

### DIFF
--- a/lib/section-ref.ts
+++ b/lib/section-ref.ts
@@ -1,0 +1,58 @@
+/**
+ * SectionRef — the identity of a Class Section.
+ *
+ * A section's identity is the `{ class_nbr, term }` pair: a section number
+ * repeats across terms, so neither field identifies a section alone. This module
+ * reifies that pair as a plain value with free helpers (function-first style, no
+ * class), so callers pass one thing instead of re-pairing two loose strings.
+ *
+ * The snake_case field names match the `class_states` / `class_watches` rows and
+ * `ClassCheckMessage`, which are already structurally `SectionRef` — they flow in
+ * without conversion or wrapping.
+ *
+ * This is a prefactor: it adds the value and its helpers but wires no consumers.
+ */
+
+/**
+ * The identity of a Class Section: its section number plus the term it runs in.
+ * Both fields are required — a `class_nbr` repeats across terms.
+ */
+export interface SectionRef {
+  /** Section number (e.g. "12431") */
+  class_nbr: string;
+  /** Term code (e.g. "2261" for Spring 2026) */
+  term: string;
+}
+
+/**
+ * Minimal structural shape of a Supabase query/filter builder: an `.eq()` that
+ * narrows by a column and returns itself for chaining. Both the real
+ * `PostgrestFilterBuilder` and a test fake satisfy this.
+ */
+interface SectionRefFilter {
+  eq(column: 'class_nbr' | 'term', value: string): this;
+}
+
+/**
+ * Apply both `class_nbr` and `term` equality filters to a Supabase query builder
+ * and return it for chaining. Callers keep control of `select`/`single`/`count`,
+ * but cannot add one `.eq` without the other — dropping `term` becomes impossible
+ * rather than a silent wrong-term read.
+ */
+export function applySectionRef<Q extends SectionRefFilter>(query: Q, ref: SectionRef): Q {
+  return query.eq('class_nbr', ref.class_nbr).eq('term', ref.term);
+}
+
+/**
+ * Stable map key derived from both fields, in `term:class_nbr` order — the shape
+ * of the hand-written `` `${term}:${class_nbr}` `` section-state map keys it is
+ * meant to replace, so keys never collide across terms.
+ */
+export function sectionRefKey(ref: SectionRef): string {
+  return `${ref.term}:${ref.class_nbr}`;
+}
+
+/** Whether two SectionRefs identify the same Class Section (both fields equal). */
+export function sectionRefEquals(a: SectionRef, b: SectionRef): boolean {
+  return a.class_nbr === b.class_nbr && a.term === b.term;
+}

--- a/tests/unit/lib/section-ref.test.ts
+++ b/tests/unit/lib/section-ref.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  applySectionRef,
+  type SectionRef,
+  sectionRefEquals,
+  sectionRefKey,
+} from '@/lib/section-ref';
+import type { ClassStateRow, ClassWatchRow } from '@/lib/types/class-watch';
+import type { ClassCheckMessage } from '@/lib/types/queue';
+
+/**
+ * Records every `.eq(column, value)` call and returns itself for chaining,
+ * mirroring the shape of a Supabase query/filter builder.
+ */
+class FakeQueryBuilder {
+  readonly calls: Array<{ column: string; value: string }> = [];
+
+  eq(column: 'class_nbr' | 'term', value: string): this {
+    this.calls.push({ column, value });
+    return this;
+  }
+}
+
+describe('applySectionRef', () => {
+  it('applies both class_nbr and term equality filters', () => {
+    const query = new FakeQueryBuilder();
+    const ref: SectionRef = { class_nbr: '12431', term: '2261' };
+
+    applySectionRef(query, ref);
+
+    expect(query.calls).toEqual([
+      { column: 'class_nbr', value: '12431' },
+      { column: 'term', value: '2261' },
+    ]);
+  });
+
+  it('returns the same builder for chaining', () => {
+    const query = new FakeQueryBuilder();
+
+    const result = applySectionRef(query, { class_nbr: '12431', term: '2261' });
+
+    expect(result).toBe(query);
+  });
+});
+
+describe('sectionRefKey', () => {
+  it('derives a term:class_nbr key from both fields', () => {
+    expect(sectionRefKey({ class_nbr: '12431', term: '2261' })).toBe('2261:12431');
+  });
+
+  it('distinguishes the same class_nbr across different terms', () => {
+    const current = sectionRefKey({ class_nbr: '12431', term: '2261' });
+    const next = sectionRefKey({ class_nbr: '12431', term: '2267' });
+
+    expect(current).not.toBe(next);
+  });
+});
+
+describe('sectionRefEquals', () => {
+  it('is true when both fields match', () => {
+    expect(
+      sectionRefEquals({ class_nbr: '12431', term: '2261' }, { class_nbr: '12431', term: '2261' })
+    ).toBe(true);
+  });
+
+  it('is false when the class_nbr differs', () => {
+    expect(
+      sectionRefEquals({ class_nbr: '12431', term: '2261' }, { class_nbr: '99999', term: '2261' })
+    ).toBe(false);
+  });
+
+  it('is false when the term differs', () => {
+    expect(
+      sectionRefEquals({ class_nbr: '12431', term: '2261' }, { class_nbr: '12431', term: '2267' })
+    ).toBe(false);
+  });
+});
+
+describe('structural compatibility', () => {
+  it('existing rows and ClassCheckMessage satisfy SectionRef with no wrapping', () => {
+    // Compile-time proof: each shape is assignable to SectionRef directly.
+    const message = {
+      class_nbr: '1',
+      term: '2261',
+      enqueued_at: '',
+      stagger_group: 'even',
+    } as const;
+    const fromMessage: SectionRef = message satisfies ClassCheckMessage;
+    const fromState: SectionRef = { class_nbr: '1', term: '2261' } as ClassStateRow;
+    const fromWatch: SectionRef = { class_nbr: '1', term: '2261' } as ClassWatchRow;
+
+    expect(sectionRefEquals(fromMessage, fromState)).toBe(true);
+    expect(sectionRefEquals(fromState, fromWatch)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Prefactor for #275 (parent PRD #274). Reifies a **Class Section's identity** — the `{ class_nbr, term }` pair — as a plain value with free helpers (function-first, no class), so callers pass one thing instead of re-pairing two loose strings.

Adds `lib/section-ref.ts`:
- **`SectionRef`** type — `{ class_nbr, term }`, snake_case to match `class_states` / `class_watches` rows and `ClassCheckMessage` (which satisfy it structurally, no conversion).
- **`applySectionRef(query, ref)`** — applies **both** `.eq('class_nbr', …)` and `.eq('term', …)` to a Supabase query builder and returns it for chaining, so a caller cannot add one filter without the other. Generic over the builder type, so `select`/`single`/`count` chaining is preserved (verified compatible with the real `PostgrestFilterBuilder`).
- **`sectionRefKey(ref)`** — `term:class_nbr` map key so keys never collide across terms.
- **`sectionRefEquals(a, b)`** — equality derived from both fields.

## Scope

Prefactor only — **wires no consumers yet**, so it lands safely and unblocks the SectionRef-dependent slices of #274 to proceed in parallel. The deferred per-shape read (`getClassState(ref)`) is intentionally **not** included.

## Tests

`tests/unit/lib/section-ref.test.ts` (8 tests, pure-function style matching `change-detector.test.ts`):
- fake query builder asserts both `.eq`s land, in order, and the builder is returned for chaining;
- key + equality helpers, including same-`class_nbr`-different-`term` non-collision;
- compile-time proof that existing rows and `ClassCheckMessage` satisfy `SectionRef` with no wrapping.

## Validation

- `bun run check` — pass (format + lint + app type-check)
- `bun run type-check` — pass (app + worker tsconfigs)
- `bun run test:run` — pass (60 files, 698 tests)

Closes #275