### PR TITLE
fix(admin): make class-detail route term-aware to fix two-term 404 (#278)

### DIFF
--- a/app/admin/classes/[term]/[classNbr]/page.tsx
+++ b/app/admin/classes/[term]/[classNbr]/page.tsx
@@ -16,12 +16,14 @@ import {
 } from '@/components/ui/table';
 import { verifyAdmin } from '@/lib/auth/admin';
 import { getClassWatchers } from '@/lib/db/queries';
+import { applySectionRef } from '@/lib/section-ref';
 import { getServiceClient } from '@/lib/supabase/service';
 import { getSeatBadgeVariant } from '@/lib/utils/seat-badge';
 import { formatRelativeTime } from '@/lib/utils/time-format';
 
 interface AdminClassDetailPageProps {
   params: Promise<{
+    term: string;
     classNbr: string;
   }>;
 }
@@ -35,22 +37,24 @@ interface AdminClassDetailPageProps {
  * - Last checked/changed timestamps
  *
  * Requires admin authentication via verifyAdmin().
- * Uses dynamic route parameter [classNbr] to fetch class data.
+ * Uses dynamic route parameters [term]/[classNbr] to fetch the exact section —
+ * a class_nbr repeats across terms, so both fields are required to identify one.
  */
 export default async function AdminClassDetailPage({ params }: AdminClassDetailPageProps) {
   // Verify admin authentication (redirects if unauthorized)
   await verifyAdmin();
 
   // Resolve params promise
-  const { classNbr } = await params;
+  const { term, classNbr } = await params;
 
-  // Fetch class state from database
+  // Fetch the exact class state by its SectionRef identity (class_nbr + term).
+  // applySectionRef filters on both fields, so a section number shared by two
+  // terms resolves to one row instead of tripping .single()'s multi-row error.
   const supabase = getServiceClient();
-  const { data: classState, error: classError } = await supabase
-    .from('class_states')
-    .select('*')
-    .eq('class_nbr', classNbr)
-    .single();
+  const { data: classState, error: classError } = await applySectionRef(
+    supabase.from('class_states').select('*'),
+    { class_nbr: classNbr, term }
+  ).single();
 
   // Handle case where class not found
   if (classError || !classState) {

--- a/app/admin/users/[userId]/page.tsx
+++ b/app/admin/users/[userId]/page.tsx
@@ -223,7 +223,7 @@ export default async function AdminUserDetailPage({ params }: AdminUserDetailPag
                     <TableRow key={watch.id}>
                       <TableCell className="font-mono font-semibold">
                         <Link
-                          href={`/admin/classes/${watch.class_nbr}`}
+                          href={`/admin/classes/${watch.term}/${watch.class_nbr}`}
                           className="text-primary hover:underline"
                         >
                           {watch.class_nbr}

--- a/components/admin/ClassesTable.tsx
+++ b/components/admin/ClassesTable.tsx
@@ -223,12 +223,12 @@ export function ClassesTable({
                   key={classItem.id}
                   className="cursor-pointer hover:bg-muted/50 transition-colors"
                   onClick={() => {
-                    router.push(`/admin/classes/${classItem.class_nbr}`);
+                    router.push(`/admin/classes/${classItem.term}/${classItem.class_nbr}`);
                   }}
                 >
                   <TableCell className="font-mono font-semibold">
                     <Link
-                      href={`/admin/classes/${classItem.class_nbr}`}
+                      href={`/admin/classes/${classItem.term}/${classItem.class_nbr}`}
                       className="text-primary hover:underline"
                       onClick={(e) => e.stopPropagation()}
                     >

--- a/tests/unit/components/admin/table-components.test.tsx
+++ b/tests/unit/components/admin/table-components.test.tsx
@@ -209,7 +209,7 @@ describe('admin table components (server-driven)', () => {
     render(<ClassesTable {...defaultClassProps} classes={classes} total={2} />);
 
     fireEvent.click(screen.getByText('Calculus I').closest('tr') as HTMLTableRowElement);
-    expect(mockPush).toHaveBeenCalledWith('/admin/classes/23456');
+    expect(mockPush).toHaveBeenCalledWith('/admin/classes/2261/23456');
   });
 
   it('sort header clicks update URL searchParams', () => {

--- a/tests/unit/pages/admin-pages.test.tsx
+++ b/tests/unit/pages/admin-pages.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import AdminClassDetailPage from '@/app/admin/classes/[classNbr]/page';
+import AdminClassDetailPage from '@/app/admin/classes/[term]/[classNbr]/page';
 import AdminClassesPage from '@/app/admin/classes/page';
 import AdminLayout from '@/app/admin/layout';
 import AdminDashboardPage from '@/app/admin/page';
@@ -190,6 +190,38 @@ const classRows = [
   },
 ];
 
+/**
+ * class_states rows the service-client mock filters over. Reset to `classRows`
+ * before each test; individual tests reassign it (e.g. the two-term case).
+ */
+let classStateFixtures: Array<Record<string, unknown>> = classRows;
+
+/**
+ * Minimal term-aware `class_states` query builder: records the `.eq` filters
+ * applySectionRef applies and resolves `.single()` to the row matching BOTH
+ * class_nbr and term — so a section number shared by two terms resolves to one
+ * row instead of the real client's multi-row error.
+ */
+function makeClassStatesQuery() {
+  const filters: Record<string, string> = {};
+  const builder = {
+    select: () => builder,
+    eq: (column: string, value: string) => {
+      filters[column] = value;
+      return builder;
+    },
+    single: () => {
+      const match = classStateFixtures.find(
+        (row) => row.class_nbr === filters.class_nbr && row.term === filters.term
+      );
+      return Promise.resolve(
+        match ? { data: match, error: null } : { data: null, error: { code: 'PGRST116' } }
+      );
+    },
+  };
+  return builder;
+}
+
 const userRows = [
   {
     id: 'user-1',
@@ -229,6 +261,7 @@ const emptySearchParams = Promise.resolve({} as Record<string, string | undefine
 describe('admin pages', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    classStateFixtures = classRows;
     mockVerifyAdmin.mockResolvedValue({ email: 'admin@example.com' });
     mockGetTotalEmailsSent.mockResolvedValue(11);
     mockGetTotalUsers.mockResolvedValue(68);
@@ -280,13 +313,7 @@ describe('admin pages', () => {
           ),
         },
       },
-      from: vi.fn(() => ({
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            single: vi.fn(() => Promise.resolve({ data: classRows[0], error: null })),
-          })),
-        })),
-      })),
+      from: vi.fn(() => makeClassStatesQuery()),
     });
   });
 
@@ -314,16 +341,52 @@ describe('admin pages', () => {
 
     fireEvent.click(screen.getByText('Class #'));
     fireEvent.click(screen.getByText('67890').closest('tr') as HTMLTableRowElement);
-    expect(mockPush).toHaveBeenCalledWith('/admin/classes/67890');
+    expect(mockPush).toHaveBeenCalledWith('/admin/classes/2261/67890');
   });
 
   it('renders class detail pages with class metadata and watchers', async () => {
-    render(await AdminClassDetailPage({ params: Promise.resolve({ classNbr: '12345' }) }));
+    render(
+      await AdminClassDetailPage({ params: Promise.resolve({ term: '2261', classNbr: '12345' }) })
+    );
 
     expect(screen.getByRole('heading', { name: /cse 240/i })).toBeInTheDocument();
     expect(screen.getByText('Class Information')).toBeInTheDocument();
     expect(screen.getByText('student@example.com')).toBeInTheDocument();
     expect(screen.getByText('12345')).toBeInTheDocument();
+  });
+
+  it('loads the requested term when a class number exists in two terms', async () => {
+    // Same class_nbr in two terms with different seats/instructor — the route must
+    // resolve the exact SectionRef, not trip .single()'s multi-row error (the #278 bug).
+    classStateFixtures = [
+      {
+        ...classRows[0],
+        id: 'state-fall',
+        term: '2257',
+        instructor_name: 'Professor Autumn',
+        seats_available: 9,
+        seats_capacity: 30,
+      },
+      {
+        ...classRows[0],
+        id: 'state-spring',
+        term: '2261',
+        instructor_name: 'Professor Vernal',
+        seats_available: 2,
+        seats_capacity: 30,
+      },
+    ];
+
+    render(
+      await AdminClassDetailPage({ params: Promise.resolve({ term: '2261', classNbr: '12345' }) })
+    );
+
+    // Shows the clicked term's data...
+    expect(screen.getByText('Professor Vernal')).toBeInTheDocument();
+    expect(screen.getByText('2/30 seats')).toBeInTheDocument();
+    // ...and never the other term's.
+    expect(screen.queryByText('Professor Autumn')).not.toBeInTheDocument();
+    expect(screen.queryByText('9/30 seats')).not.toBeInTheDocument();
   });
 
   it('renders user tables with paginated rows and supports row navigation/sorting controls', async () => {


### PR DESCRIPTION
## Summary

Fixes the live admin class-detail **404** for section numbers that repeat across terms. The page filtered `class_states` by `class_nbr` alone and called `.single()`; when a user watches the same `class_nbr` in two terms (allowed — `class_watches` is unique on `user_id, term, class_nbr`), `.single()` matched two rows and threw a spurious 404.

The route is now **term-aware**: `term` travels in the path and the exact section is loaded via `applySectionRef` (the `{ class_nbr, term }` filter helper from #275), which applies both `.eq('class_nbr')` and `.eq('term')` so `.single()` resolves exactly one row.

## Changes

- Move route `app/admin/classes/[classNbr]/page.tsx` → `app/admin/classes/[term]/[classNbr]/page.tsx`; load `class_states` via `applySectionRef(...)`.
- Pass `term` in the two links that navigate there (both already had it in hand):
  - `components/admin/ClassesTable.tsx` — row `onClick` push + `<Link href>`.
  - `app/admin/users/[userId]/page.tsx` — watch link.
- Tests: add a two-term case asserting the clicked term's seats/instructor render and the other term's do not; update the existing detail-page/params and row-navigation assertions to the term-aware path (term-aware `class_states` query fake).

## Test Plan

- [x] `bun run check` (format + lint + app type-check) — pass
- [x] `bun run type-check` (app + worker tsconfigs) — pass
- [x] `bun run test:run` — 699 passed / 60 files
- [x] New test: `class_nbr` in two terms loads the requested term (`tests/unit/pages/admin-pages.test.tsx`)

## Scope notes (deliberately out of scope)

- The **Watchers table** on the same page is still loaded via `getClassWatchers(classNbr)`, whose RPC (`get_class_watchers`) filters by `class_nbr` alone — so a two-term section shows one term's seats/instructor but a combined watcher list. Making it term-scoped needs an RPC/migration change + `database.types.ts` regen, which the parent PRD (#274) explicitly defers ("the filter helper is the minimal seam that closes the bug"). Strictly better than the prior full 404; flagged for a follow-up.
- `getUserWatches`'s `class_nbr`-only join key and the realtime hook are **#279**'s scope and left untouched here.

## Related Issues

Closes #278
