### PR TITLE
refactor(pipeline): adopt SectionRef through the seat-check pipeline (#280)

### DIFF
--- a/app/api/class-watches/route.ts
+++ b/app/api/class-watches/route.ts
@@ -127,7 +127,7 @@ export async function POST(request: NextRequest) {
 
     let classDetails: ClassDetails;
     try {
-      classDetails = await fetchClassFromASU(class_nbr, term, asuEnv);
+      classDetails = await fetchClassFromASU({ class_nbr, term }, asuEnv);
     } catch (error) {
       if (error instanceof NotFoundError) {
         return fail('Class section not found', 404);
@@ -183,7 +183,7 @@ export async function POST(request: NextRequest) {
 
     // Step 3: Persist class state
     try {
-      await upsertClassState(supabaseServiceRole, term, class_nbr, classDetails);
+      await upsertClassState(supabaseServiceRole, { class_nbr, term }, classDetails);
     } catch (dbError) {
       log('API').error('Failed to persist class state:', dbError);
       // Continue anyway - watch was created successfully

--- a/app/api/fetch-class-details/route.ts
+++ b/app/api/fetch-class-details/route.ts
@@ -44,14 +44,14 @@ export async function POST(request: NextRequest) {
     let classDetails: ClassDetails;
 
     try {
-      classDetails = await fetchClassFromASU(class_nbr, term, asuEnv);
+      classDetails = await fetchClassFromASU({ class_nbr, term }, asuEnv);
     } catch (error) {
       return mapAsuErrorToResponse(error);
     }
 
     // Persist fetched data to class_states table for immediate dashboard display
     try {
-      await upsertClassState(getServiceClient(), term, class_nbr, classDetails);
+      await upsertClassState(getServiceClient(), { class_nbr, term }, classDetails);
     } catch (dbError) {
       log('API').error('Failed to persist class state:', dbError);
       // Continue anyway - graceful degradation

--- a/app/api/monitoring/health/route.ts
+++ b/app/api/monitoring/health/route.ts
@@ -94,7 +94,7 @@ export async function GET(request: Request) {
   // 2. Check ASU API
   try {
     const asuEnv = env as unknown as { ASU_API_BASE_URL: string; ASU_API_TOKEN: string };
-    await fetchClassFromASU('10001', '2251', asuEnv);
+    await fetchClassFromASU({ class_nbr: '10001', term: '2251' }, asuEnv);
     health.checks.asu_api = {
       name: 'ASU API',
       status: 'healthy',

--- a/app/api/queue/process-section/route.ts
+++ b/app/api/queue/process-section/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
 
     // Delegate to section processor orchestrator
     try {
-      const result = await processSection(class_nbr, term, env);
+      const result = await processSection({ class_nbr, term }, env);
 
       if (!result.success) {
         return NextResponse.json(

--- a/lib/asu/api.ts
+++ b/lib/asu/api.ts
@@ -41,6 +41,8 @@ export class NotFoundError extends ApiError {
   }
 }
 
+import type { SectionRef } from '@/lib/section-ref';
+import { sectionRefKey } from '@/lib/section-ref';
 import type { ClassDetails } from '@/lib/types/class';
 import type { Env } from '@/lib/types/env';
 
@@ -154,16 +156,14 @@ function normalizeAuthHeader(token: string): string {
 
 // --- Main Function ---
 
-export async function fetchClassFromASU(
-  classNbr: string,
-  term: string,
-  env: AsuApiEnv
-): Promise<ClassDetails> {
+export async function fetchClassFromASU(ref: SectionRef, env: AsuApiEnv): Promise<ClassDetails> {
   if (!env.ASU_API_BASE_URL || !env.ASU_API_TOKEN) {
     throw new ApiError('ASU API environment variables not configured');
   }
 
-  const cacheKey = `${classNbr}:${term}`;
+  const { class_nbr: classNbr, term } = ref;
+
+  const cacheKey = sectionRefKey(ref);
   const cached = asuApiCache.get(cacheKey);
   if (cached) return cached;
 

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -6,6 +6,7 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { log } from '@/lib/log';
+import { applySectionRef, type SectionRef } from '@/lib/section-ref';
 import type { Database } from '@/lib/supabase/database.types';
 import type { ClassDetails } from '@/lib/types/class';
 import { getServiceClient } from '@/lib/supabase/service';
@@ -52,7 +53,7 @@ export async function getClassWatchers(classNbr: string): Promise<ClassWatcher[]
  */
 export async function getSectionsToCheck(
   staggerType: 'even' | 'odd' | 'all' = 'all'
-): Promise<Array<{ class_nbr: string; term: string }>> {
+): Promise<SectionRef[]> {
   const supabase = getServiceClient();
 
   const { data, error } = await supabase.rpc('get_sections_to_check', {
@@ -74,22 +75,19 @@ export async function getSectionsToCheck(
  * Called when seats fill back to zero, allowing users to be re-notified
  * when seats open again.
  *
- * @param classNbr - Section number (e.g., "12431")
- * @param term - Term code (e.g., "2261")
+ * @param ref - SectionRef identifying the section ({ class_nbr, term })
  * @param notificationType - Type of notification to reset (default: 'seat_available')
  */
 export async function resetNotificationsForSection(
-  classNbr: string,
-  term: string,
+  ref: SectionRef,
   notificationType: 'seat_available' | 'instructor_assigned' = 'seat_available'
 ): Promise<void> {
   const supabase = getServiceClient();
 
-  const { data: watches, error: watchError } = await supabase
-    .from('class_watches')
-    .select('id')
-    .eq('class_nbr', classNbr)
-    .eq('term', term);
+  const { data: watches, error: watchError } = await applySectionRef(
+    supabase.from('class_watches').select('id'),
+    ref
+  );
 
   if (watchError) {
     log('DB').error(`Error fetching watches for reset:`, watchError);
@@ -97,7 +95,7 @@ export async function resetNotificationsForSection(
   }
 
   if (!watches || watches.length === 0) {
-    log('DB').info(`No watches found for section ${classNbr}, nothing to reset`);
+    log('DB').info(`No watches found for section ${ref.class_nbr}, nothing to reset`);
     return;
   }
 
@@ -115,7 +113,7 @@ export async function resetNotificationsForSection(
   }
 
   log('DB').info(
-    `Reset ${notificationType} notifications for ${watchIds.length} watchers of section ${classNbr}`
+    `Reset ${notificationType} notifications for ${watchIds.length} watchers of section ${ref.class_nbr}`
   );
 }
 
@@ -212,16 +210,15 @@ export async function tryRecordNotificationsBatch(
  * Used by both class-watches POST and fetch-class-details POST.
  *
  * @param serviceClient - Supabase service-role client
- * @param term - Term code (e.g. "2261")
- * @param class_nbr - Section number (e.g. "12431")
+ * @param ref - SectionRef identifying the section ({ class_nbr, term })
  * @param details - Class details from the ASU API
  */
 export async function upsertClassState(
   serviceClient: SupabaseClient<Database>,
-  term: string,
-  class_nbr: string,
+  ref: SectionRef,
   details: ClassDetails
 ): Promise<void> {
+  const { class_nbr, term } = ref;
   const { error } = await serviceClient.from('class_states').upsert(
     {
       term,

--- a/lib/queue/process-section.ts
+++ b/lib/queue/process-section.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/asu/api';
 import { log } from '@/lib/log';
 import { resetNotificationsForSection } from '@/lib/db/queries';
+import { applySectionRef, type SectionRef } from '@/lib/section-ref';
 import type { ClassInfo } from '@/lib/types/class';
 import { type ChangeResult, detectChanges } from '@/lib/queue/change-detector';
 import { type SentNotification, sendSectionNotifications } from '@/lib/queue/notification-sender';
@@ -44,16 +45,15 @@ export interface ProcessingResult {
  * 5. Upsert new class state
  * 6. Send notifications if seat became available or instructor assigned
  *
- * @param classNbr - 5-digit section number (e.g., "12431")
- * @param term - 4-digit term code (e.g., "2261")
+ * @param ref - SectionRef identifying the section ({ class_nbr, term })
  * @param env - Environment bindings for ASU API and email
  * @returns ProcessingResult with timing info
  */
 export async function processSection(
-  classNbr: string,
-  term: string,
+  ref: SectionRef,
   env: Pick<Env, 'ASU_API_BASE_URL' | 'ASU_API_TOKEN' | 'EMAIL' | 'NOTIFICATION_FROM_EMAIL'>
 ): Promise<ProcessingResult> {
+  const { class_nbr: classNbr, term } = ref;
   const startTime = Date.now();
   const serviceClient = getServiceClient();
 
@@ -62,13 +62,11 @@ export async function processSection(
   let emailsSent = 0;
 
   try {
-    // Step 1: Fetch old state from DB
-    const { data: oldState, error: stateError } = await serviceClient
-      .from('class_states')
-      .select('*')
-      .eq('class_nbr', classNbr)
-      .eq('term', term)
-      .single();
+    // Step 1: Fetch old state from DB by its SectionRef identity (class_nbr + term).
+    const { data: oldState, error: stateError } = await applySectionRef(
+      serviceClient.from('class_states').select('*'),
+      ref
+    ).single();
 
     // PGRST116 = no rows found — not an error for first observation
     if (stateError && stateError.code !== 'PGRST116') {
@@ -76,7 +74,7 @@ export async function processSection(
     }
 
     // Step 2: Fetch from ASU API
-    newData = await fetchClassFromASU(classNbr, term, env);
+    newData = await fetchClassFromASU(ref, env);
 
     // Step 3: Detect changes
     changes = detectChanges(oldState, newData);
@@ -92,7 +90,7 @@ export async function processSection(
 
     // Step 4: Reset notifications if seats filled
     if (changes.seatsFilled) {
-      await resetNotificationsForSection(classNbr, term, 'seat_available');
+      await resetNotificationsForSection(ref, 'seat_available');
     }
 
     // Step 5: Upsert new class state BEFORE sending notifications.

--- a/tests/integration/api/class-watches.test.ts
+++ b/tests/integration/api/class-watches.test.ts
@@ -425,10 +425,13 @@ describe('/api/class-watches', () => {
 
       expect(response.status).toBe(201);
       expect(data.watch).toBeDefined();
-      expect(mockFetchClassFromASU).toHaveBeenCalledWith('12345', '2264', {
-        ASU_API_BASE_URL: expect.any(String),
-        ASU_API_TOKEN: expect.any(String),
-      });
+      expect(mockFetchClassFromASU).toHaveBeenCalledWith(
+        { class_nbr: '12345', term: '2264' },
+        {
+          ASU_API_BASE_URL: expect.any(String),
+          ASU_API_TOKEN: expect.any(String),
+        }
+      );
       expect(mockRpc).toHaveBeenCalledWith(
         'create_class_watch_with_limit',
         expect.objectContaining({

--- a/tests/integration/api/fetch-class-details.test.ts
+++ b/tests/integration/api/fetch-class-details.test.ts
@@ -119,10 +119,13 @@ describe('/api/fetch-class-details', () => {
       instructor_name: 'Dr. Smith',
       seats_available: 7,
     });
-    expect(mockFetchClassFromASU).toHaveBeenCalledWith('12345', '2264', {
-      ASU_API_BASE_URL: 'https://classes.example.test',
-      ASU_API_TOKEN: 'test-token',
-    });
+    expect(mockFetchClassFromASU).toHaveBeenCalledWith(
+      { class_nbr: '12345', term: '2264' },
+      {
+        ASU_API_BASE_URL: 'https://classes.example.test',
+        ASU_API_TOKEN: 'test-token',
+      }
+    );
     expect(mockUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         term: '2264',

--- a/tests/integration/api/process-section.test.ts
+++ b/tests/integration/api/process-section.test.ts
@@ -368,8 +368,7 @@ describe('POST /api/queue/process-section', () => {
       expect(data.success).toBe(true);
       expect(data.changes_detected.seats_filled).toBe(true);
       expect(mockResetNotificationsForSection).toHaveBeenCalledWith(
-        '12345',
-        '2261',
+        { class_nbr: '12345', term: '2261' },
         'seat_available'
       );
     });

--- a/tests/integration/worker-queue.test.ts
+++ b/tests/integration/worker-queue.test.ts
@@ -148,7 +148,10 @@ describe('worker queue handler — direct processSection call ack/retry mapping'
 
     expect(msg.ack).toHaveBeenCalledOnce();
     expect(msg.retry).not.toHaveBeenCalled();
-    expect(mockProcessSection).toHaveBeenCalledWith('12345', '2261', mockEnv);
+    expect(mockProcessSection).toHaveBeenCalledWith(
+      expect.objectContaining({ class_nbr: '12345', term: '2261' }),
+      mockEnv
+    );
   });
 
   it('retries message when processSection returns success:false (DB upsert error)', async () => {

--- a/tests/unit/lib/asu-api.test.ts
+++ b/tests/unit/lib/asu-api.test.ts
@@ -84,10 +84,14 @@ describe('fetchClassFromASU', () => {
       .spyOn(global, 'fetch')
       .mockResolvedValue(new Response(JSON.stringify(buildAsuSuccessResponse()), { status: 200 }));
 
-    const result = await fetchClassFromASU('42737', '2264', {
-      ASU_API_BASE_URL: 'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-      ASU_API_TOKEN: 'null',
-    });
+    const result = await fetchClassFromASU(
+      { class_nbr: '42737', term: '2264' },
+      {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'null',
+      }
+    );
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0];
@@ -115,11 +119,14 @@ describe('fetchClassFromASU', () => {
       .spyOn(global, 'fetch')
       .mockResolvedValue(new Response(JSON.stringify(buildAsuSuccessResponse()), { status: 200 }));
 
-    await fetchClassFromASU('42737', '2264', {
-      ASU_API_BASE_URL:
-        'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1/search/classes',
-      ASU_API_TOKEN: 'Bearer null',
-    });
+    await fetchClassFromASU(
+      { class_nbr: '42737', term: '2264' },
+      {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1/search/classes',
+        ASU_API_TOKEN: 'Bearer null',
+      }
+    );
 
     const [url, init] = fetchSpy.mock.calls[0];
     const parsedUrl = new URL(url as string);
@@ -134,9 +141,11 @@ describe('fetchClassFromASU', () => {
     ['base URL', { ASU_API_BASE_URL: '', ASU_API_TOKEN: 'test-token' }],
     ['token', { ASU_API_BASE_URL: 'https://example.com/api/v1', ASU_API_TOKEN: '' }],
   ])('should reject when the ASU API %s is missing', async (_field, env) => {
-    await expect(fetchClassFromASU('42737', '2264', env)).rejects.toSatisfy((error: unknown) => {
-      return error instanceof ApiError && error.message.includes('not configured');
-    });
+    await expect(fetchClassFromASU({ class_nbr: '42737', term: '2264' }, env)).rejects.toSatisfy(
+      (error: unknown) => {
+        return error instanceof ApiError && error.message.includes('not configured');
+      }
+    );
   });
 
   it('should serve repeated class lookups from cache', async () => {
@@ -149,8 +158,8 @@ describe('fetchClassFromASU', () => {
       ASU_API_TOKEN: 'test-token',
     };
 
-    const first = await fetchClassFromASU('42737', '2264', env);
-    const second = await fetchClassFromASU('42737', '2264', env);
+    const first = await fetchClassFromASU({ class_nbr: '42737', term: '2264' }, env);
+    const second = await fetchClassFromASU({ class_nbr: '42737', term: '2264' }, env);
 
     expect(first).toEqual(second);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -161,11 +170,14 @@ describe('fetchClassFromASU', () => {
     vi.spyOn(global, 'fetch').mockRejectedValue(timeoutError);
 
     await expect(
-      fetchClassFromASU('42737', '2264', {
-        ASU_API_BASE_URL:
-          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-        ASU_API_TOKEN: 'test-token',
-      })
+      fetchClassFromASU(
+        { class_nbr: '42737', term: '2264' },
+        {
+          ASU_API_BASE_URL:
+            'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+          ASU_API_TOKEN: 'test-token',
+        }
+      )
     ).rejects.toSatisfy((error: unknown) => {
       return error instanceof ApiError && error.status === 408;
     });
@@ -176,11 +188,14 @@ describe('fetchClassFromASU', () => {
     vi.spyOn(global, 'fetch').mockRejectedValue(timeoutError);
 
     await expect(
-      fetchClassFromASU('42737', '2264', {
-        ASU_API_BASE_URL:
-          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-        ASU_API_TOKEN: 'test-token',
-      })
+      fetchClassFromASU(
+        { class_nbr: '42737', term: '2264' },
+        {
+          ASU_API_BASE_URL:
+            'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+          ASU_API_TOKEN: 'test-token',
+        }
+      )
     ).rejects.toThrow('ASU API request timed out');
   });
 
@@ -189,11 +204,14 @@ describe('fetchClassFromASU', () => {
     vi.spyOn(global, 'fetch').mockRejectedValue(networkError);
 
     await expect(
-      fetchClassFromASU('42737', '2264', {
-        ASU_API_BASE_URL:
-          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-        ASU_API_TOKEN: 'test-token',
-      })
+      fetchClassFromASU(
+        { class_nbr: '42737', term: '2264' },
+        {
+          ASU_API_BASE_URL:
+            'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+          ASU_API_TOKEN: 'test-token',
+        }
+      )
     ).rejects.toBe(networkError);
   });
 
@@ -206,11 +224,14 @@ describe('fetchClassFromASU', () => {
     vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}', { status }));
 
     await expect(
-      fetchClassFromASU('42737', '2264', {
-        ASU_API_BASE_URL:
-          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-        ASU_API_TOKEN: 'test-token',
-      })
+      fetchClassFromASU(
+        { class_nbr: '42737', term: '2264' },
+        {
+          ASU_API_BASE_URL:
+            'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+          ASU_API_TOKEN: 'test-token',
+        }
+      )
     ).rejects.toSatisfy((error: unknown) => {
       return error instanceof ErrorClass && error.message.includes(message);
     });
@@ -225,11 +246,14 @@ describe('fetchClassFromASU', () => {
     );
 
     await expect(
-      fetchClassFromASU('42737', '2264', {
-        ASU_API_BASE_URL:
-          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-        ASU_API_TOKEN: 'test-token',
-      })
+      fetchClassFromASU(
+        { class_nbr: '42737', term: '2264' },
+        {
+          ASU_API_BASE_URL:
+            'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+          ASU_API_TOKEN: 'test-token',
+        }
+      )
     ).rejects.toBeInstanceOf(NotFoundError);
   });
 
@@ -241,10 +265,14 @@ describe('fetchClassFromASU', () => {
       })
     );
 
-    const result = await fetchClassFromASU('12345', '2264', {
-      ASU_API_BASE_URL: 'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-      ASU_API_TOKEN: 'test-token',
-    });
+    const result = await fetchClassFromASU(
+      { class_nbr: '12345', term: '2264' },
+      {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'test-token',
+      }
+    );
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result.non_reserved_seats).toBe(15);
@@ -258,10 +286,14 @@ describe('fetchClassFromASU', () => {
       })
     );
 
-    const result = await fetchClassFromASU('12345', '2264', {
-      ASU_API_BASE_URL: 'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-      ASU_API_TOKEN: 'test-token',
-    });
+    const result = await fetchClassFromASU(
+      { class_nbr: '12345', term: '2264' },
+      {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'test-token',
+      }
+    );
 
     expect(result.non_reserved_seats).toBe(0);
   });
@@ -272,10 +304,14 @@ describe('fetchClassFromASU', () => {
       new Response(JSON.stringify(buildAsuSuccessResponse()), { status: 200 })
     );
 
-    const result = await fetchClassFromASU('42737', '2264', {
-      ASU_API_BASE_URL: 'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-      ASU_API_TOKEN: 'null',
-    });
+    const result = await fetchClassFromASU(
+      { class_nbr: '42737', term: '2264' },
+      {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'null',
+      }
+    );
 
     expect(result.non_reserved_seats).toBe(21);
   });
@@ -351,10 +387,14 @@ describe('fetchClassFromASU', () => {
       new Response(JSON.stringify(responseWithMultipleHits), { status: 200 })
     );
 
-    const result = await fetchClassFromASU('42737', '2264', {
-      ASU_API_BASE_URL: 'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-      ASU_API_TOKEN: 'test-token',
-    });
+    const result = await fetchClassFromASU(
+      { class_nbr: '42737', term: '2264' },
+      {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'test-token',
+      }
+    );
 
     // Should return the class with CLASSNBR='42737', not the first hit (CLASSNBR='99999')
     expect(result.subject).toBe('ABS');
@@ -416,11 +456,14 @@ describe('fetchClassFromASU', () => {
     );
 
     await expect(
-      fetchClassFromASU('99999', '2264', {
-        ASU_API_BASE_URL:
-          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-        ASU_API_TOKEN: 'test-token',
-      })
+      fetchClassFromASU(
+        { class_nbr: '99999', term: '2264' },
+        {
+          ASU_API_BASE_URL:
+            'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+          ASU_API_TOKEN: 'test-token',
+        }
+      )
     ).rejects.toSatisfy((error: unknown) => {
       return error instanceof Error && error.message.includes('Section 99999 not found');
     });
@@ -461,10 +504,14 @@ describe('fetchClassFromASU', () => {
       new Response(JSON.stringify(responseWithEmptyStrings), { status: 200 })
     );
 
-    const result = await fetchClassFromASU('12345', '2264', {
-      ASU_API_BASE_URL: 'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-      ASU_API_TOKEN: 'test-token',
-    });
+    const result = await fetchClassFromASU(
+      { class_nbr: '12345', term: '2264' },
+      {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'test-token',
+      }
+    );
 
     // All seat counts should be valid numbers, not NaN
     expect(result.seats_capacity).toBe(0);
@@ -504,10 +551,14 @@ describe('fetchClassFromASU', () => {
       )
     );
 
-    const result = await fetchClassFromASU('55555', '2264', {
-      ASU_API_BASE_URL: 'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-      ASU_API_TOKEN: 'test-token',
-    });
+    const result = await fetchClassFromASU(
+      { class_nbr: '55555', term: '2264' },
+      {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'test-token',
+      }
+    );
 
     expect(result).toMatchObject({
       title: 'First-Year Composition',
@@ -541,10 +592,14 @@ describe('fetchClassFromASU', () => {
       )
     );
 
-    const result = await fetchClassFromASU('66666', '2264', {
-      ASU_API_BASE_URL: 'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
-      ASU_API_TOKEN: 'test-token',
-    });
+    const result = await fetchClassFromASU(
+      { class_nbr: '66666', term: '2264' },
+      {
+        ASU_API_BASE_URL:
+          'https://eadvs-cscc-catalog-api.apps.asu.edu/catalog-microservices/api/v1',
+        ASU_API_TOKEN: 'test-token',
+      }
+    );
 
     expect(result.title).toBe('Unknown');
     expect(result.meeting_times).toBe('TBD');

--- a/tests/unit/lib/db/notification-expiration.test.ts
+++ b/tests/unit/lib/db/notification-expiration.test.ts
@@ -139,7 +139,7 @@ describe('Notification Expiration (Issue #157)', () => {
         })),
       });
 
-      await resetNotificationsForSection('12345', '2261', 'seat_available');
+      await resetNotificationsForSection({ class_nbr: '12345', term: '2261' }, 'seat_available');
 
       expect(mockFrom).toHaveBeenCalledWith('class_watches');
     });
@@ -162,9 +162,9 @@ describe('Notification Expiration (Issue #157)', () => {
         select: vi.fn(() => mockQuery),
       });
 
-      await expect(resetNotificationsForSection('12345', '2261')).rejects.toThrow(
-        'Failed to fetch watches: Connection error'
-      );
+      await expect(
+        resetNotificationsForSection({ class_nbr: '12345', term: '2261' })
+      ).rejects.toThrow('Failed to fetch watches: Connection error');
     });
 
     it('should do nothing when no watches found', async () => {
@@ -185,7 +185,7 @@ describe('Notification Expiration (Issue #157)', () => {
         select: vi.fn(() => mockQuery),
       });
 
-      await resetNotificationsForSection('12345', '2261', 'seat_available');
+      await resetNotificationsForSection({ class_nbr: '12345', term: '2261' }, 'seat_available');
 
       // Should not call delete when no watches found
       expect(mockFrom).toHaveBeenCalledTimes(1);
@@ -214,7 +214,10 @@ describe('Notification Expiration (Issue #157)', () => {
         })),
       });
 
-      await resetNotificationsForSection('12345', '2261', 'instructor_assigned');
+      await resetNotificationsForSection(
+        { class_nbr: '12345', term: '2261' },
+        'instructor_assigned'
+      );
 
       expect(mockFrom).toHaveBeenCalledWith('class_watches');
     });
@@ -242,7 +245,7 @@ describe('Notification Expiration (Issue #157)', () => {
         })),
       });
 
-      await resetNotificationsForSection('12345', '2261');
+      await resetNotificationsForSection({ class_nbr: '12345', term: '2261' });
 
       // Should default to seat_available
       expect(mockFrom).toHaveBeenCalledWith('class_watches');
@@ -271,7 +274,7 @@ describe('Notification Expiration (Issue #157)', () => {
         })),
       });
 
-      await resetNotificationsForSection('12345', '2261');
+      await resetNotificationsForSection({ class_nbr: '12345', term: '2261' });
 
       expect(mockQuery.eq).toHaveBeenCalledWith('class_nbr', '12345');
       expect(mockQuery.eq).toHaveBeenCalledWith('term', '2261');

--- a/tests/unit/lib/db/queries-notifications.test.ts
+++ b/tests/unit/lib/db/queries-notifications.test.ts
@@ -46,7 +46,7 @@ describe('resetNotificationsForSection (characterization)', () => {
     mockFrom.mockReturnValue({ select: vi.fn(() => selectQuery) });
 
     await expect(
-      resetNotificationsForSection('12345', '2261', 'seat_available')
+      resetNotificationsForSection({ class_nbr: '12345', term: '2261' }, 'seat_available')
     ).resolves.toBeUndefined();
 
     // Only the class_watches fetch happens; no delete chain is invoked.
@@ -58,9 +58,9 @@ describe('resetNotificationsForSection (characterization)', () => {
     const selectQuery = mockWatchFetch({ data: null, error: { message: 'Connection error' } });
     mockFrom.mockReturnValue({ select: vi.fn(() => selectQuery) });
 
-    await expect(resetNotificationsForSection('12345', '2261')).rejects.toThrow(
-      'Failed to fetch watches: Connection error'
-    );
+    await expect(
+      resetNotificationsForSection({ class_nbr: '12345', term: '2261' })
+    ).rejects.toThrow('Failed to fetch watches: Connection error');
   });
 
   it('delete error → throws "Failed to reset notifications"', async () => {
@@ -76,9 +76,9 @@ describe('resetNotificationsForSection (characterization)', () => {
       })),
     });
 
-    await expect(resetNotificationsForSection('12345', '2261', 'seat_available')).rejects.toThrow(
-      'Failed to reset notifications: delete blew up'
-    );
+    await expect(
+      resetNotificationsForSection({ class_nbr: '12345', term: '2261' }, 'seat_available')
+    ).rejects.toThrow('Failed to reset notifications: delete blew up');
   });
 });
 

--- a/tests/unit/lib/queue/process-section.test.ts
+++ b/tests/unit/lib/queue/process-section.test.ts
@@ -151,7 +151,7 @@ describe('processSection', () => {
 
   it('successful full flow: fetches, detects, notifies, and persists', async () => {
     const env = buildEnv();
-    const result = await processSection('42737', '2261', env);
+    const result = await processSection({ class_nbr: '42737', term: '2261' }, env);
 
     // Should have fetched old state with correct chaining (includes term)
     const db = getServiceClient() as unknown as ReturnType<typeof buildMockDb>;
@@ -161,8 +161,8 @@ describe('processSection', () => {
     expect(db.eq).toHaveBeenCalledWith('term', '2261');
     expect(db.single).toHaveBeenCalled();
 
-    // Should have fetched from ASU
-    expect(fetchClassFromASU).toHaveBeenCalledWith('42737', '2261', env);
+    // Should have fetched from ASU with the SectionRef
+    expect(fetchClassFromASU).toHaveBeenCalledWith({ class_nbr: '42737', term: '2261' }, env);
 
     // Should have detected changes
     expect(detectChanges).toHaveBeenCalled();
@@ -195,7 +195,7 @@ describe('processSection', () => {
   it('no changes detected: only persists, no notifications', async () => {
     (detectChanges as ReturnType<typeof vi.fn>).mockReturnValue(buildChangeResult());
 
-    const result = await processSection('42737', '2261', buildEnv());
+    const result = await processSection({ class_nbr: '42737', term: '2261' }, buildEnv());
 
     expect(sendSectionNotifications).not.toHaveBeenCalled();
     expect(resetNotificationsForSection).not.toHaveBeenCalled();
@@ -208,9 +208,12 @@ describe('processSection', () => {
       buildChangeResult({ seatsFilled: true, newOpenSeats: 0 })
     );
 
-    const result = await processSection('42737', '2261', buildEnv());
+    const result = await processSection({ class_nbr: '42737', term: '2261' }, buildEnv());
 
-    expect(resetNotificationsForSection).toHaveBeenCalledWith('42737', '2261', 'seat_available');
+    expect(resetNotificationsForSection).toHaveBeenCalledWith(
+      { class_nbr: '42737', term: '2261' },
+      'seat_available'
+    );
     expect(sendSectionNotifications).not.toHaveBeenCalled();
     expect(result.success).toBe(true);
   });
@@ -221,7 +224,7 @@ describe('processSection', () => {
       new NotFoundError('Section 42737 not found')
     );
 
-    await expect(processSection('42737', '2261', buildEnv())).rejects.toThrow(
+    await expect(processSection({ class_nbr: '42737', term: '2261' }, buildEnv())).rejects.toThrow(
       'Section 42737 not found'
     );
     // Should NOT have tried to persist or notify
@@ -236,7 +239,9 @@ describe('processSection', () => {
       new RateLimitError('Rate limit hit')
     );
 
-    await expect(processSection('42737', '2261', buildEnv())).rejects.toThrow('Rate limit hit');
+    await expect(processSection({ class_nbr: '42737', term: '2261' }, buildEnv())).rejects.toThrow(
+      'Rate limit hit'
+    );
   });
 
   it('DB upsert fails: returns error result', async () => {
@@ -247,7 +252,7 @@ describe('processSection', () => {
     mockDb.upsert.mockResolvedValue({ error: { message: 'Constraint violation' } });
     (getServiceClient as ReturnType<typeof vi.fn>).mockReturnValue(mockDb);
 
-    const result = await processSection('42737', '2261', buildEnv());
+    const result = await processSection({ class_nbr: '42737', term: '2261' }, buildEnv());
 
     expect(result).toMatchObject({
       success: false,
@@ -273,7 +278,7 @@ describe('processSection', () => {
       buildChangeResult({ seatBecameAvailable: true, newOpenSeats: 3 })
     );
 
-    const result = await processSection('42737', '2261', buildEnv());
+    const result = await processSection({ class_nbr: '42737', term: '2261' }, buildEnv());
 
     // detectChanges should have been called with null oldState (PGRST116 returns data: null)
     expect(detectChanges).toHaveBeenCalledWith(
@@ -300,7 +305,7 @@ describe('processSection', () => {
     });
     (getServiceClient as ReturnType<typeof vi.fn>).mockReturnValue(mockDb);
 
-    const result = await processSection('42737', '2261', buildEnv());
+    const result = await processSection({ class_nbr: '42737', term: '2261' }, buildEnv());
 
     // non-PGRST116 errors log but don't stop processing
     expect(console.error).toHaveBeenCalledWith(
@@ -330,7 +335,7 @@ describe('processSection', () => {
         buildChangeResult({ seatBecameAvailable: true, newOpenSeats: 5 })
       );
 
-      const result = await processSection('42737', '2261', buildEnv());
+      const result = await processSection({ class_nbr: '42737', term: '2261' }, buildEnv());
 
       // Persist-before-send: a failed upsert must short-circuit BEFORE any emails go out,
       // so a retry re-attempts cleanly with no duplicate emails.

--- a/worker.ts
+++ b/worker.ts
@@ -484,7 +484,7 @@ export default {
       batch.messages.map(async (message) => {
         const msgStartTime = Date.now();
         try {
-          const result = await processSection(message.body.class_nbr, message.body.term, env);
+          const result = await processSection(message.body, env);
           const duration = Date.now() - msgStartTime;
 
           if (result.success) {


### PR DESCRIPTION
## What

Adopts **SectionRef** through the seat-check pipeline so dropping `term` becomes a compile error pipeline-wide. No user-visible behavior change — this locks the `(class_nbr, term)` identity invariant by threading the value type through the code paths that previously passed the pair as loose strings.

Closes #280. Parent: #274.

## Changes

- **ASU client** (`lib/asu/api.ts`): `fetchClassFromASU(ref, env)` now takes a `SectionRef`; cache key derived via `sectionRefKey`.
- **processSection** (`lib/queue/process-section.ts`): `processSection(ref, env)` takes a `SectionRef`; the `class_states` baseline read uses `applySectionRef` (both `.eq`s).
- **Section DB queries** (`lib/db/queries.ts`): `resetNotificationsForSection(ref, type)` and `upsertClassState(client, ref, details)` take a `SectionRef`; the `class_watches` reset read uses `applySectionRef`; `getSectionsToCheck` returns `SectionRef[]`.
- **Callers updated**: cron enqueue, worker queue consumer, HTTP mirror route, `class-watches`, `fetch-class-details`, and `monitoring/health`.

The load-bearing `processSection` ordering (reset → upsert `class_states` → send) and the worker/HTTP ack-vs-retry equivalence are preserved.

## Acceptance criteria

- [x] ASU client, `processSection`, section queries, and cron enqueue accept/produce `SectionRef` rather than re-pairing loose strings
- [x] Section-scoped DB reads/writes use `applySectionRef` (no bare single-field `.eq('class_nbr')` remain on section paths)
- [x] No behavior change: dedup ordering and ack/retry semantics preserved
- [x] Existing pipeline unit + integration tests stay green
- [x] `bun run type-check` (app + worker) passes
- [x] `bun run check`, `bun run knip`, `bun run build`, and `bun run test:run` (699 tests) pass

## Testing

`bun run type-check`, `bun run check`, `bun run knip`, `bun run build`, and `bun run test:run` all pass locally.
